### PR TITLE
fix accessibility on key figs and timeline left menu

### DIFF
--- a/components/KeyFiguresPage/KeyFiguresPage.module.scss
+++ b/components/KeyFiguresPage/KeyFiguresPage.module.scss
@@ -91,7 +91,6 @@
   .key_figures__active_item {
     color: $vividViolet;
     display: flex;
-    outline: none;
 
     span {
       height: 2px;

--- a/components/KeyFiguresPage/KeyFiguresPage.module.scss
+++ b/components/KeyFiguresPage/KeyFiguresPage.module.scss
@@ -79,7 +79,8 @@
   }
 
   a:focus {
-    outline: none;
+    text-decoration: none;
+    opacity: 1;
   }
 
   a:active {
@@ -90,6 +91,7 @@
   .key_figures__active_item {
     color: $vividViolet;
     display: flex;
+    outline: none;
 
     span {
       height: 2px;

--- a/components/KeyFiguresPage/KeyFiguresPage.module.scss
+++ b/components/KeyFiguresPage/KeyFiguresPage.module.scss
@@ -75,10 +75,16 @@
 
   a:hover {
     text-decoration: none;
+    opacity: 1;
   }
 
   a:focus {
     outline: none;
+  }
+
+  a:active {
+    outline: 0.25rem solid $outlineColor;
+    opacity: 1;
   }
 
   .key_figures__active_item {

--- a/components/TimelinePage/TimelinePage.module.scss
+++ b/components/TimelinePage/TimelinePage.module.scss
@@ -15,6 +15,20 @@
     ul {
       list-style: none;
     }
+
+    a:hover {
+      text-decoration: none;
+      opacity: 1;
+    }
+
+    a:focus {
+      outline: none;
+    }
+
+    a:active {
+      outline: 0.25rem solid $outlineColor;
+      opacity: 1;
+    }
   
     .timeline__active_item {
       color: $vividViolet;

--- a/components/TimelinePage/TimelinePage.module.scss
+++ b/components/TimelinePage/TimelinePage.module.scss
@@ -22,7 +22,8 @@
     }
 
     a:focus {
-      outline: none;
+      text-decoration: none;
+      opacity: 1;
     }
 
     a:active {
@@ -33,6 +34,7 @@
     .timeline__active_item {
       color: $vividViolet;
       display: flex;
+      outline: none;
 
       span {
         height: 2px;

--- a/components/TimelinePage/TimelinePage.module.scss
+++ b/components/TimelinePage/TimelinePage.module.scss
@@ -34,7 +34,6 @@
     .timeline__active_item {
       color: $vividViolet;
       display: flex;
-      outline: none;
 
       span {
         height: 2px;


### PR DESCRIPTION
This adds back in the accessibility box around the timeline and key figs lefthand menu items when they are active (i.e. during the moment they are being clicked).  It also makes the text of the menu items black when you hover over them (normally they are grey).