### PR TITLE
Lighthouse seo

### DIFF
--- a/components/CollectionsPage/CollectionHeader/index.js
+++ b/components/CollectionsPage/CollectionHeader/index.js
@@ -4,7 +4,7 @@ import scss from "components/CollectionsPage/CollectionHeader/CollectionHeader.m
 const CollectionHeader = ({ image, years, name, styledText, description }) => {
   return (
     <section className={scss.collection_header}>
-      <img src={image} />
+      <img src={image} alt={name} />
 
       <div className={scss.collection_header__intro}>
         <h3>{years}</h3>

--- a/components/CollectionsPage/ItemList/index.js
+++ b/components/CollectionsPage/ItemList/index.js
@@ -25,7 +25,7 @@ const ItemList = ({ collection, items }) => {
             <Link href="/collections/[colId]/[colItemId]"
               as={`/collections/${collection.colId}/${item.colItemId}`}>
               <a>
-                <img src={item.thumb} />
+                <img src={item.thumb} alt={item.title} />
                 <p className={scss.item__title}>{item.title}</p>
                 <p className={scss.item__date}>{item.date}</p>
               </a>

--- a/components/ItemComponents/Content/Content.module.scss
+++ b/components/ItemComponents/Content/Content.module.scss
@@ -278,6 +278,10 @@ $listPadding: 1.125rem;
 
 .otherMetadataItem {
   font-size: 1rem;
+
+  span {
+    line-height: 1.8;
+  }
 }
 
 .rightsMetadata {

--- a/components/KeyFiguresPage/KeyFiguresPagination/KeyFiguresPagination.module.scss
+++ b/components/KeyFiguresPage/KeyFiguresPagination/KeyFiguresPagination.module.scss
@@ -67,6 +67,7 @@
 @media only screen and ($md-viewport) {
 
   .pagination__container {
+    padding-bottom: 5em;
 
     .pagination__next {
       width: 50%;

--- a/components/KeyFiguresPage/Sources/Sources.module.scss
+++ b/components/KeyFiguresPage/Sources/Sources.module.scss
@@ -12,17 +12,17 @@
     font-size: 14px;
     font-weight: $xBold;
     letter-spacing: 1.2px;
-    line-height: 17px;
+    line-height: 28px;
     margin-bottom: 0;
   }
 
   li {
     color: #282830;
     font-family: $inter;
-    font-size: 14px;
+    font-size: 1em;
     font-weight: 500;
     letter-spacing: 0.31px;
-    line-height: 24px;
+    padding-bottom: 0.5em
   }
 
   div {

--- a/components/SearchPage/OptionsBar/index.js
+++ b/components/SearchPage/OptionsBar/index.js
@@ -136,7 +136,8 @@ class OptionsBar extends React.Component {
                   <span className={css.activeFacetCount}>
                     ({numberOfActiveFacets})
                 </span>}
-                <img className={css.filtersButtonChevron} src="static/icon/search/icon-search-dropdown.svg" />
+                <img className={css.filtersButtonChevron} src="static/icon/search/icon-search-dropdown.svg"
+                  alt="Dropdown menu icon" />
               </button>
             </div>
 

--- a/components/TimelinePage/TimelinePage.module.scss
+++ b/components/TimelinePage/TimelinePage.module.scss
@@ -140,21 +140,23 @@
     p {
       margin-bottom: 15px;
       font-family: $inter;
-      font-size: 14px;
+      font-size: 1em;
       font-weight: 500;
       letter-spacing: 0.31px;
-      line-height: 24px;
+      line-height: 28px;
     }
 
     ul {
       color: $jaguar;
       font-family: $inter;
-      font-size: 14px;
       font-weight: 500;
       letter-spacing: 0.31px;
-      line-height: 24px;
       list-style-type: disc;
       padding-left: 18px;
+    }
+
+    li {
+      padding-bottom: 0.5em;
     }
   }
 }

--- a/components/TimelinePage/TimelinePage.module.scss
+++ b/components/TimelinePage/TimelinePage.module.scss
@@ -140,7 +140,7 @@
     p {
       margin-bottom: 15px;
       font-family: $inter;
-      font-size: 1em;
+      font-size: 14px;
       font-weight: 500;
       letter-spacing: 0.31px;
       line-height: 28px;
@@ -153,6 +153,7 @@
       letter-spacing: 0.31px;
       list-style-type: disc;
       padding-left: 18px;
+      font-size: 1em;
     }
 
     li {

--- a/components/shared/Breadcrumbs/Breadcrumbs.module.scss
+++ b/components/shared/Breadcrumbs/Breadcrumbs.module.scss
@@ -34,6 +34,7 @@
   align-items: center;
   display: flex;
   position: relative;
+  padding-bottom: 0.3em;
 
   &:after {
     content: "";

--- a/components/shared/Pagination/Pagination.module.scss
+++ b/components/shared/Pagination/Pagination.module.scss
@@ -20,7 +20,7 @@
   color: $paginationLinkColor;
   font-size: 1.125rem;
   padding: 3px 10px;
-  margin: 0 3px;
+  margin: 0 6px;
   border-radius: 50%;
   font-weight: $bold;
 }

--- a/components/shared/SearchBar/index.js
+++ b/components/shared/SearchBar/index.js
@@ -31,7 +31,7 @@ class SearchBar extends React.Component {
             <Link href="/search">
               <a>
                 ADVANCED SEARCH
-              <img src="/static/icon/button-arrow-purple.png" />
+              <img src="/static/icon/button-arrow-purple.png" alt="Arrow icon" />
               </a>
             </Link>
           </div>


### PR DESCRIPTION
 This fixes the Lighthouse SEO problems.  Alt text is added to images; some links are spaced slightly farther apart for mobile touch targets. The only outstanding issue is that the link to the about page in the top banner on the home page says "LEARN MORE" which is apparently too vague to make search engines happy.  We could change it to something like "LEARN MORE ABOUT THE PROJECT" but the pithiness of the original text sits well with the other text in the banner, so I didn't feel comfortable changing it without a second opinion.