### PR TITLE
load-bearing empty file

### DIFF
--- a/constants/womans-era.js
+++ b/constants/womans-era.js
@@ -1,0 +1,18 @@
+{
+    "womans-era" : {
+    "title" : [ ],
+        "creator" : [ "unknown" ],
+        "subject" : [ ],
+        "isPartOf" : [ "Mary Church Terrell" ],
+        "type" : [  ],
+        "format" : [  ],
+        "date" : [ ],
+        "identifier" : [  ],
+        "rights" : [  ],
+        "description" : [ ],
+        "spatial" : [  ],
+        "publisher" : [  ],
+        "language" : [ ],
+        "href" : ""
+}
+}

--- a/constants/womans-era.js
+++ b/constants/womans-era.js
@@ -3,7 +3,7 @@
     "title" : [ ],
         "creator" : [ "unknown" ],
         "subject" : [ ],
-        "isPartOf" : [ "Mary Church Terrell" ],
+        "isPartOf" : [ "Womans Era" ],
         "type" : [  ],
         "format" : [  ],
         "date" : [ ],


### PR DESCRIPTION
It turns out you need a file for a collection that is an offlink 
so that next.js static site generation doesn't explode.