### PR TITLE
Fix React hydration errors (nested Link/a) and item page SSR crashes

### DIFF
--- a/components/ItemComponents/Content/FacetLink.js
+++ b/components/ItemComponents/Content/FacetLink.js
@@ -4,13 +4,10 @@ import Link from "next/link";
 const FacetLink = ({ facet, value, facetLabel }) =>
   <Link
     href={{ pathname: "/search", query: { [facet]: `"${value}"` } }}
+    className="link"
+    title={`Find more items with ${facetLabel || facet} "${value}"`}
   >
-    <a
-      className="link"
-      title={`Find more items with ${facetLabel || facet} "${value}"`}
-    >
-      {value}
-    </a>
+    {value}
   </Link>;
 
 export default FacetLink;

--- a/components/MainLayout/components/Footer/index.js
+++ b/components/MainLayout/components/Footer/index.js
@@ -15,25 +15,11 @@ const Footer = () => {
           </div>          
 
           <nav className={scss.footer__links} data-cy="footer__links">
-            <Link href="/about">
-              <a>About</a>
-            </Link>
-
-            <Link href="/timeline">
-              <a>Timeline</a>
-            </Link>
-
-            <Link href="/key-figures">
-              <a>Key Figures</a>
-            </Link>
-
-            <Link href="/collections">
-              <a>Collections</a>
-            </Link>
-
-            <Link href="/partners">
-              <a>Partners</a>
-            </Link>
+            <Link href="/about">About</Link>
+            <Link href="/timeline">Timeline</Link>
+            <Link href="/key-figures">Key Figures</Link>
+            <Link href="/collections">Collections</Link>
+            <Link href="/partners">Partners</Link>
           </nav>
 
           <a href="http://dp.la/" rel="noopener" target="_blank" data-cy="footer__logo_dpla"> 
@@ -46,9 +32,7 @@ const Footer = () => {
           <nav className={scss.footer__links_small} data-cy="footer__links_small">
             <a href="http://dp.la/" rel="noopener" target="_blank" className={scss.footer__a}> Visit DPLA</a>
 
-            <Link href="/harmful-language-statement">
-              <a>Harmful Language Statement</a>
-            </Link>
+            <Link href="/harmful-language-statement">Harmful Language Statement</Link>
           </nav>
 
           <section className={scss.footer__section_bottom}>

--- a/components/SearchPage/FiltersList/index.js
+++ b/components/SearchPage/FiltersList/index.js
@@ -46,15 +46,12 @@ const Filter = ({ name, queryKey, route }) => {
           pathname: route.pathname,
           query: Object.assign({}, clearFacet(route.query, queryKey, name))
         }}
+        className={css.filterLink}
+        title={`Remove ${label} ${name} filter`}
+        aria-label={`Remove ${label} ${name} filter`}
       >
-        <a
-          className={css.filterLink}
-          title={`Remove ${label} ${name} filter`}
-          aria-label={`Remove ${label} ${name} filter`}
-        >
-          {label}: <span className={css.filterText}>{name}</span>
-          <img src={closeIcon} alt={`clear ${name} filter`} />
-        </a>
+        {label}: <span className={css.filterText}>{name}</span>
+        <img src={closeIcon} alt={`clear ${name} filter`} />
       </Link>
     </li>
   );
@@ -113,8 +110,8 @@ class FiltersList extends React.Component {
                 pathname: this.props.route.pathname,
                 query: Object.assign({}, clearAllFacets(query))
               }}
+              className={css.clearAll}
             >
-              <a className={css.clearAll}>
                 <svg
                   className={css.clearAllIcon}
                   width="18"
@@ -131,7 +128,6 @@ class FiltersList extends React.Component {
                   </g>
                 </svg>
                 <span>Clear all filters</span>
-              </a>
             </Link>
           </div>
         </div>

--- a/components/SearchPage/FiltersList/index.js
+++ b/components/SearchPage/FiltersList/index.js
@@ -51,7 +51,7 @@ const Filter = ({ name, queryKey, route }) => {
         aria-label={`Remove ${label} ${name} filter`}
       >
         {label}: <span className={css.filterText}>{name}</span>
-        <img src={closeIcon} alt={`clear ${name} filter`} />
+        <img src={closeIcon} alt="" aria-hidden="true" />
       </Link>
     </li>
   );

--- a/components/SearchPage/MainContent/Sidebar/index.js
+++ b/components/SearchPage/MainContent/Sidebar/index.js
@@ -36,15 +36,14 @@ const FacetLink = ({ route, queryKey, termObject, disabled }) =>
             page: 1
           })
         }}
+        className={css.facet}
       >
-        <a className={css.facet}>
-          <span className={css.facetName}>
-            {`${termObject.term} `}
-          </span>
-          <span className={css.facetCount}>
-            {addCommasToNumber(termObject.count)}
-          </span>
-        </a>
+        <span className={css.facetName}>
+          {`${termObject.term} `}
+        </span>
+        <span className={css.facetCount}>
+          {addCommasToNumber(termObject.count)}
+        </span>
       </Link>;
 
 class DateFacet extends React.Component {

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -65,6 +65,9 @@ export async function getServerSideProps(context) {
     const json = await apiRes.json();
 
     const doc = json.docs[0];
+    if (!doc) {
+      return { notFound: true };
+    }
     const thumbnailUrl = getItemThumbnail(doc);
     const date = doc.sourceResource.date &&
       Array.isArray(doc.sourceResource.date)


### PR DESCRIPTION
## Summary

- Removes all `<Link><a>` nested patterns across the codebase — in `FacetLink` (item detail), `FiltersList`, `Sidebar`, and `Footer`. Since Next.js 13+, `Link` renders its own `<a>` tag; wrapping a child `<a>` produces nested anchors that browsers split on parse, causing the server DOM to differ from what React expects and throwing hydration error #418 (one per affected link) followed by #423 (React falls back to full client render). Item pages with 6 subjects + type + partner + contributor were seeing 11 × #418 on every page load.
- Adds an empty-docs guard in `pages/item/[itemId].js` `getServerSideProps` — if the API returns zero docs, return `notFound: true` instead of falling through to crash on `doc.sourceResource`. (The `res.ok` check and catch-block `notFound` were already added upstream in d0ac29a.)

## Test plan

- [ ] Load an item page (e.g. `/item/63973a78e3370251331073fd5adfd8d0`) — console should show no React hydration errors
- [ ] Load search results with active facet filters — Filter pills and sidebar facet links should render and navigate correctly
- [ ] Load the footer — nav links should work
- [ ] Request an item ID that doesn't exist — should return 404, not 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added server-side guard to return a not-found page when requested item data is missing to prevent errors and crashes.

* **Refactor**
  * Simplified link markup across navigation, search filters, and sidebars by removing nested anchors and applying attributes directly for cleaner structure.

* **Accessibility**
  * Improved accessible labeling for filter controls and icons (aria attributes and image alt usage) for clearer screen-reader behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->