### PR TITLE
Fix PDF streaming broken by Next.js 15 Web API ReadableStream

### DIFF
--- a/pages/api/dpla/pdf/[collectionId]/[pdfId].js
+++ b/pages/api/dpla/pdf/[collectionId]/[pdfId].js
@@ -39,6 +39,15 @@ const pdfSender = async (req, res) => {
         return;
     }
     res.setHeader("Content-Type", "application/pdf");
+    const contentLength = pdf.headers.get("content-length");
+    if (contentLength) {
+        res.setHeader("Content-Length", contentLength);
+    }
+    if (!pdf.body) {
+        res.statusCode = 502;
+        res.end("Failed to fetch PDF.");
+        return;
+    }
     Readable.fromWeb(pdf.body)
         .on("error", (err) => {
             console.error("[PDF] Stream error:", err);

--- a/pages/api/dpla/pdf/[collectionId]/[pdfId].js
+++ b/pages/api/dpla/pdf/[collectionId]/[pdfId].js
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { Readable } from "stream";
 
 const pdfSender = async (req, res) => {
     const { query: {collectionId, pdfId}} = req;
@@ -24,9 +25,18 @@ const pdfSender = async (req, res) => {
     const url = new URL(item.href);
     url.protocol = "http";
     const pdf = await fetch(url.toString());
-    const pdfStream = pdf.body
-    pdfStream.on('close', () => { res.end() });
-    pdfStream.pipe(res);
+    if (!pdf.ok) {
+        res.statusCode = 502;
+        res.end("Failed to fetch PDF.");
+        return;
+    }
+    res.setHeader("Content-Type", "application/pdf");
+    Readable.fromWeb(pdf.body)
+        .on("error", (err) => {
+            console.error("[PDF] Stream error:", err);
+            res.end();
+        })
+        .pipe(res);
 
 }
 

--- a/pages/api/dpla/pdf/[collectionId]/[pdfId].js
+++ b/pages/api/dpla/pdf/[collectionId]/[pdfId].js
@@ -24,7 +24,15 @@ const pdfSender = async (req, res) => {
     const item = json[pdfId];
     const url = new URL(item.href);
     url.protocol = "http";
-    const pdf = await fetch(url.toString());
+    let pdf;
+    try {
+        pdf = await fetch(url.toString());
+    } catch (err) {
+        console.error("[PDF] Fetch error:", err);
+        res.statusCode = 502;
+        res.end("Failed to fetch PDF.");
+        return;
+    }
     if (!pdf.ok) {
         res.statusCode = 502;
         res.end("Failed to fetch PDF.");

--- a/pages/api/dpla/pdf/[collectionId]/[pdfId].js
+++ b/pages/api/dpla/pdf/[collectionId]/[pdfId].js
@@ -34,6 +34,7 @@ const pdfSender = async (req, res) => {
         return;
     }
     if (!pdf.ok) {
+        console.error("[PDF] Upstream error:", pdf.status, pdf.statusText);
         res.statusCode = 502;
         res.end("Failed to fetch PDF.");
         return;

--- a/pages/api/dpla/pdf/[collectionId]/[pdfId].js
+++ b/pages/api/dpla/pdf/[collectionId]/[pdfId].js
@@ -26,7 +26,7 @@ const pdfSender = async (req, res) => {
     url.protocol = "http";
     let pdf;
     try {
-        pdf = await fetch(url.toString());
+        pdf = await fetch(url.toString(), { signal: AbortSignal.timeout(30000) });
     } catch (err) {
         console.error("[PDF] Fetch error:", err);
         res.statusCode = 502;
@@ -51,7 +51,12 @@ const pdfSender = async (req, res) => {
     pipeline(Readable.fromWeb(pdf.body), res, (err) => {
         if (err) {
             console.error("[PDF] Stream error:", err);
-            res.destroy(err);
+            if (!res.headersSent) {
+                res.statusCode = 502;
+                res.end("Stream error");
+            } else {
+                res.destroy(err);
+            }
         }
     });
 

--- a/pages/api/dpla/pdf/[collectionId]/[pdfId].js
+++ b/pages/api/dpla/pdf/[collectionId]/[pdfId].js
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { Readable } from "stream";
+import { Readable, pipeline } from "stream";
 
 const pdfSender = async (req, res) => {
     const { query: {collectionId, pdfId}} = req;
@@ -38,22 +38,22 @@ const pdfSender = async (req, res) => {
         res.end("Failed to fetch PDF.");
         return;
     }
-    res.setHeader("Content-Type", "application/pdf");
-    const contentLength = pdf.headers.get("content-length");
-    if (contentLength) {
-        res.setHeader("Content-Length", contentLength);
-    }
     if (!pdf.body) {
         res.statusCode = 502;
         res.end("Failed to fetch PDF.");
         return;
     }
-    Readable.fromWeb(pdf.body)
-        .on("error", (err) => {
+    const contentLength = pdf.headers.get("content-length");
+    if (contentLength) {
+        res.setHeader("Content-Length", contentLength);
+    }
+    res.setHeader("Content-Type", "application/pdf");
+    pipeline(Readable.fromWeb(pdf.body), res, (err) => {
+        if (err) {
             console.error("[PDF] Stream error:", err);
-            res.end();
-        })
-        .pipe(res);
+            res.destroy(err);
+        }
+    });
 
 }
 


### PR DESCRIPTION
## Summary

- The PDF proxy route (`/api/dpla/pdf/[collectionId]/[pdfId]`) has been returning 500 on every request since the Next.js upgrade. Root cause: the old code called `.on()` and `.pipe()` on `pdf.body`, which worked under Next.js 9's `node-fetch` polyfill (which returned a Node.js `Readable` stream). Since Next.js 14/15, the runtime uses the native Node.js 18 `fetch`, whose response `.body` is a Web API `ReadableStream` — no `.on()` or `.pipe()` methods exist on it, so every request threw a `TypeError` and returned 500.
- Fix: `Readable.fromWeb(pdf.body)` converts the Web stream to a Node.js stream before piping to `res`.
- Also adds a `pdf.ok` check (returns 502 if S3 responds with an error) and a stream `error` event handler to cleanly end the response if the transfer fails mid-flight rather than leaving the connection hanging.

## Test plan

- [ ] `GET /api/dpla/pdf/ida-b-wells/ibwells-0008-0012` — should stream a PDF (was 500)
- [ ] `GET /api/dpla/pdf/ida-b-wells/ibwells-0001-001-008` — should stream a PDF (was 500)
- [ ] `GET /api/dpla/pdf/unknown-collection/anything` — should return 404
- [ ] `GET /api/dpla/pdf/ida-b-wells/unknown-id` — should return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of PDF downloads by validating upstream responses before streaming.
  * Returns HTTP 502 when fetching the PDF fails or when the upstream response is invalid or missing a body.
  * Ensures PDF responses include the correct Content-Type and forwards Content-Length when available.
  * Switched to a robust streaming pipeline with error handling to log failures and safely terminate transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->