### PR TITLE
fix: prevent 5xx upstream errors from rendering as 404s

### DIFF
--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -156,6 +156,7 @@ export async function getServerSideProps(context) {
     };
 
     if (page > MAX_PAGE_SIZE) {
+        context.res.statusCode = 400;
         return { props: emptySearchProps };
     }
 


### PR DESCRIPTION
## Summary

- **search page**: Distinguish 5xx upstream errors (→ HTTP 503 + empty results, allowing crawlers to retry) from genuine 4xx/not-found (→ HTTP 404). Network errors also return 503. Set statusCode 400 when the requested page exceeds `MAX_PAGE_SIZE`.
- **item page**: Move the API fetch outside the try block so a 5xx response throws and propagates to Next.js's error handler (HTTP 500) rather than silently rendering a misleading 404. The try block now covers only JSON parsing.

**Why it matters:** Returning `{ notFound: true }` for transient 5xx errors tells search engines the content no longer exists — permanent 404 treatment for what is actually a temporary availability problem.

## Test plan

- [ ] Search: verify HTTP 503 is returned when the API is down, not 404
- [ ] Search: verify page > MAX_PAGE_SIZE returns HTTP 400 with empty results
- [ ] Item: verify HTTP 500 is returned for a 5xx upstream error, not 404
- [ ] Item: verify HTTP 404 is still returned for a genuine 404 from the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Error Handling Improvements for Upstream API Failures

This PR fixes incorrect HTTP status code responses when the upstream DPLA API returns 5xx or network errors, preventing search engines and crawlers from treating temporarily unavailable content as permanently missing.

### Changes

**Search page** (`pages/search/index.js`)
- Returns HTTP 400 (with empty results) when the requested page exceeds `MAX_PAGE_SIZE`.
- Distinguishes upstream statuses:
  - Preserves HTTP 404/410 for genuine not-found responses.
  - Maps upstream 429 and any 5xx or network errors to HTTP 503, sets `Retry-After: 10`, and returns empty results (so crawlers can retry).
  - Maps other non-OK upstream statuses to HTTP 502 and returns empty results.
- For unexpected exceptions during fetch, sets HTTP 503 with `Retry-After: 10` and returns empty results (instead of rendering as 404).

**Item detail page** (`pages/item/[itemId].js`)
- Moves the upstream fetch and HTTP-status handling outside the outer try block so non-OK upstream responses (5xx) throw and propagate to Next.js’s error handler, resulting in HTTP 500 (instead of returning `{ notFound: true }` / 404).
- Limits the remaining try/catch to JSON parsing and downstream shaping so genuine upstream 404s still return 404.
- On unexpected parsing/errors, errors are logged and rethrown rather than converted into a 404.

### Impact / Notes

- No manual pipeline trigger or ECS redeployment required — these are application code changes only.
- No additions/removals/renames of environment variables or AWS Secrets Manager keys.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No modification of public API response shapes or new/removed endpoints — behavior changes are server-side rendering/status mapping only.
- Security implications: none beyond existing behavior; no authentication, credential handling, or new external inputs introduced.
- Tests / verification plan described in PR:
  - Confirm search returns 503 (not 404) when API is down.
  - Confirm search page > MAX_PAGE_SIZE returns 400 with empty results.
  - Confirm item page returns 500 for upstream 5xx (not 404).
  - Confirm item page still returns 404 for genuine API 404 responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->