### PR TITLE
fix(search): show error message on API outage instead of false no-results

### DIFF
--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -99,7 +99,8 @@ export async function getServerSideProps(context) {
       })
     } };
   } catch (error) {
-    console.error('[Item] Unexpected error:', error.message || String(error));
+    const safeMsg = (error.message || String(error)).replace(/api_key=[^&\s]*/g, "api_key=[redacted]");
+    console.error('[Item] Unexpected error:', safeMsg);
     return { notFound: true };
   }
 };

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -183,9 +183,6 @@ export async function getServerSideProps(context) {
         });
         if (!res.ok) {
             console.error(`[Search] API request failed: ${res.status} ${res.statusText}`);
-            if (res.status === 404 || res.status === 410) {
-                return { notFound: true };
-            }
             if (res.status === 429 || res.status >= 500) {
                 context.res.statusCode = 503;
                 context.res.setHeader("Retry-After", "10");
@@ -196,7 +193,8 @@ export async function getServerSideProps(context) {
         }
         json = await res.json();
     } catch (error) {
-        console.error("[Search] Unexpected error:", error.message || String(error));
+        const safeMsg = (error.message || String(error)).replace(/api_key=[^&\s]*/g, "api_key=[redacted]");
+        console.error("[Search] Unexpected error:", safeMsg);
         context.res.statusCode = 503;
         context.res.setHeader("Retry-After", "10");
         return { props: { ...emptySearchProps, errorState: true } };

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -27,7 +27,7 @@ import {
 
 const apiVersion = process.env.API_VERSION || "v2";
 
-const Search = ({ results, numberOfActiveFacets, pageCount, currentPage, pageSize, query }) => {
+const Search = ({ results, numberOfActiveFacets, pageCount, currentPage, pageSize, query, errorState }) => {
     const router = useRouter();
     const [showSidebar, setShowSidebar] = useState(false);
 
@@ -50,21 +50,26 @@ const Search = ({ results, numberOfActiveFacets, pageCount, currentPage, pageSiz
                     "Search results" :
                     `Search results for "${query}"`}
             />
-            <OptionsBar
+            {!errorState && <OptionsBar
                 showFilters={showSidebar}
                 currentPage={currentPage}
                 route={router}
                 itemCount={itemCount}
                 onClickToggleFilters={toggleFilters}
                 numberOfActiveFacets={numberOfActiveFacets}
-            />
-            <FiltersList
+            />}
+            {!errorState && <FiltersList
                 showFilters={showSidebar}
                 onClickToggleFilters={toggleFilters}
                 route={router}
                 facets={results.facets}
-            />
-            {currentPage <= MAX_PAGE_SIZE &&
+            />}
+            {errorState && (
+                <p style={{ textAlign: "center", padding: "2rem" }}>
+                    Search results couldn&apos;t be loaded. Please try again.
+                </p>
+            )}
+            {!errorState && currentPage <= MAX_PAGE_SIZE &&
             <MainContent
                 hideSidebar={!showSidebar}
                 paginationInfo={{
@@ -76,7 +81,7 @@ const Search = ({ results, numberOfActiveFacets, pageCount, currentPage, pageSiz
                 facets={results.facets}
                 results={results.docs}
             />}
-            {currentPage > MAX_PAGE_SIZE &&
+            {!errorState && currentPage > MAX_PAGE_SIZE &&
             <MaxPageError maxPage={MAX_PAGE_SIZE} requestedPage={currentPage} />}
         </MainLayout>
     );
@@ -144,7 +149,8 @@ export async function getServerSideProps(context) {
         currentPage: Number(page),
         pageCount: 0,
         pageSize: page_size,
-        query: query.q || null
+        query: query.q || null,
+        errorState: false
     };
 
     if (page > MAX_PAGE_SIZE) {
@@ -175,12 +181,23 @@ export async function getServerSideProps(context) {
         });
         if (!res.ok) {
             console.error(`[Search] API request failed: ${res.status} ${res.statusText}`);
-            return { notFound: true };
+            if (res.status === 404 || res.status === 410) {
+                return { notFound: true };
+            }
+            if (res.status === 429 || res.status >= 500) {
+                context.res.statusCode = 503;
+                context.res.setHeader("Retry-After", "10");
+                return { props: { ...emptySearchProps, errorState: true } };
+            }
+            context.res.statusCode = 502;
+            return { props: { ...emptySearchProps, errorState: true } };
         }
         json = await res.json();
     } catch (error) {
         console.error("[Search] Unexpected error:", error.message || String(error));
-        return { notFound: true };
+        context.res.statusCode = 503;
+        context.res.setHeader("Retry-After", "10");
+        return { props: { ...emptySearchProps, errorState: true } };
     }
 
     const docs = json.docs ? json.docs.map(result => {
@@ -215,7 +232,8 @@ export async function getServerSideProps(context) {
             currentPage: Number(page),
             pageCount,
             pageSize: page_size,
-            query: query.q || null
+            query: query.q || null,
+            errorState: false
         }
     };
 }

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -8,6 +8,8 @@ import MainContent from "components/SearchPage/MainContent";
 import MaxPageError from "components/SearchPage/MaxPageError";
 import BWSHead from "components/BWSHead";
 
+import css from "./search.module.scss";
+
 import {
     getItemThumbnail,
     splitAndURIEncodeFacet,
@@ -65,7 +67,7 @@ const Search = ({ results, numberOfActiveFacets, pageCount, currentPage, pageSiz
                 facets={results.facets}
             />}
             {errorState && (
-                <p style={{ textAlign: "center", padding: "2rem" }}>
+                <p className={css.errorMessage}>
                     Search results couldn&apos;t be loaded. Please try again.
                 </p>
             )}

--- a/pages/search/search.module.scss
+++ b/pages/search/search.module.scss
@@ -1,0 +1,4 @@
+.errorMessage {
+  text-align: center;
+  padding: 2rem;
+}


### PR DESCRIPTION
## Summary

- When the DPLA API returns 429/5xx or throws, the search page was rendering "Your search did not match any items" with spelling suggestions — misleading users during an outage
- All non-200 responses were also returning `notFound: true`, sending a 404 for upstream errors (crawlers treat this as "page doesn't exist")
- Narrows `notFound` to genuine 404/410 responses only
- Returns 503 + `Retry-After: 10` for 429 and 5xx; 502 for other non-ok statuses
- Adds an `errorState` boolean prop; gates `OptionsBar`, `FiltersList`, `MainContent`, and `MaxPageError` on `!errorState`
- Renders "Search results couldn't be loaded. Please try again." when `errorState` is set

Matches the `fetchError` pattern already in use in dpla-frontend's search page.

## Test plan

- [ ] Normal search: results render as expected, no change in behaviour
- [ ] Simulate API outage (e.g. bad `API_URL`): search page shows "Search results couldn't be loaded. Please try again." with correct HTTP 503 response, not a false no-results page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## fix(search): show error message on API outage instead of false no-results

### What changed
The search page now distinguishes genuine "no results" from upstream DPLA API outages and surfaces an error UI and appropriate HTTP status codes.

Client-side (React)
- Added `errorState` boolean prop to the Search component.
- When `errorState` is true, the page renders a centered message: "Search results couldn't be loaded. Please try again." and hides OptionsBar, FiltersList, MainContent, and MaxPageError.
- Added `.errorMessage` CSS class in pages/search/search.module.scss for the error UI.

Server-side
- getServerSideProps in pages/search/index.js now:
  - Returns `{ notFound: true }` only for genuine upstream 404/410 responses.
  - For 429 and >=500 responses sets `context.res.statusCode = 503`, adds `Retry-After: "10"`, and returns props with `errorState: true`.
  - For other non-OK upstream responses sets `context.res.statusCode = 502` and returns props with `errorState: true`.
  - Exception catch-blocks set `503` + `Retry-After: "10"` and return `errorState: true`.
- Error logging in pages/item/[itemId].js (catch block) now redacts `api_key=...` from logged error messages before console.error to avoid leaking credentials in logs.

Files changed (high level)
- pages/search/index.js — add errorState handling, status/headers logic, and error props.
- pages/search/search.module.scss — `.errorMessage` class.
- pages/item/[itemId].js — sanitized error logging to redact api_key.

### Public API / responses
- The search page endpoint behavior for upstream non-200 responses changed:
  - Only upstream 404/410 produce Next.js 404 (notFound).
  - Upstream rate-limit (429) and server errors (5xx) yield HTTP 503 with `Retry-After: 10`.
  - Other non-OK upstream statuses yield HTTP 502.
- Returned props now include an added `errorState: boolean` (clients reading props will see this new field).

### Testing considerations
- Confirm normal searches behave unchanged.
- Simulate DPLA API outage (e.g., misconfigured API_URL or force 429/5xx) — page should show the error message and return 503 with `Retry-After: 10` (instead of a false no-results page).
- Verify upstream 404/410 still surface Next.js 404 behavior.
- Verify error logs no longer include raw `api_key` values.

### Infrastructure / deploy / security notes
- No manual pipeline trigger, ECS redeploy, environment variable, Secrets Manager key, database migration, or shared infra (CodePipeline/CodeBuild/ECS task/IAM) changes are required beyond deploying this code.
- Security: improved logging hygiene — redacts `api_key` from error messages before logging to avoid credential leakage. No other auth/credential changes or new external inputs.

### Additional notes
- Matches the existing `fetchError` pattern used in dpla-frontend's search page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->