### PR TITLE
fix(item): return 503/502 for upstream errors instead of 404

### DIFF
--- a/components/ItemComponents/itemComponent.module.scss
+++ b/components/ItemComponents/itemComponent.module.scss
@@ -32,3 +32,8 @@
 .notFound {
   margin: 0 0 3rem;
 }
+
+.errorMessage {
+  text-align: center;
+  padding: 2rem;
+}

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -15,7 +15,20 @@ import {
 
 import css from "components/ItemComponents/itemComponent.module.scss";
 
-const ItemDetail = ({url, item}) => {
+const ItemDetail = ({url, item, errorState}) => {
+  if (errorState || !item) {
+    return (
+      <MainLayout>
+        <BWSHead pageTitle="Item unavailable | DPLA" />
+        <main id="main" role="main" className="container">
+          <p className={css.errorMessage}>
+            This item couldn&apos;t be loaded. Please try again.
+          </p>
+        </main>
+      </MainLayout>
+    );
+  }
+
   return (
     <MainLayout>
       <BWSHead
@@ -60,7 +73,11 @@ export async function getServerSideProps(context) {
     );
     if (!apiRes.ok) {
       console.error(`[Item] API request failed: ${apiRes.status} ${apiRes.statusText}`);
-      return { notFound: true };
+      if (apiRes.status === 404 || apiRes.status === 410) {
+        return { notFound: true };
+      }
+      context.res.statusCode = apiRes.status === 429 || apiRes.status >= 500 ? 503 : 502;
+      return { props: { url, item: null, errorState: true } };
     }
     const json = await apiRes.json();
 
@@ -101,7 +118,8 @@ export async function getServerSideProps(context) {
   } catch (error) {
     const safeMsg = (error.message || String(error)).replace(/api_key=[^&\s]*/g, "api_key=[redacted]");
     console.error('[Item] Unexpected error:', safeMsg);
-    return { notFound: true };
+    context.res.statusCode = 503;
+    return { props: { url, item: null, errorState: true } };
   }
 };
 export default ItemDetail;

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -116,7 +116,7 @@ export async function getServerSideProps(context) {
       })
     } };
   } catch (error) {
-    const safeMsg = (error.message || String(error)).replace(/api_key=[^&\s]*/g, "api_key=[redacted]");
+    const safeMsg = String(error?.message ?? error).replace(/api_key=[^&\s]*/g, "api_key=[redacted]");
     console.error('[Item] Unexpected error:', safeMsg);
     context.res.statusCode = 503;
     return { props: { url, item: null, errorState: true } };


### PR DESCRIPTION
## Summary

- Upstream API 5xx and transport failures were returning `{ notFound: true }`, making item pages appear permanently deleted during outages
- 404/410 from API → `notFound: true` (correct — item genuinely missing)
- 429/5xx from API → 503 + error UI
- Other non-OK (including retired endpoints) → 502 + error UI
- Network/transport errors in catch → 503 + error UI, `api_key` redacted from logs
- Adds `errorState` rendering path to `ItemDetail` with `<BWSHead>` and CSS module class
- Guards `if (errorState || !item)` to prevent null-crash regression

Companion to #149 (search page error state). CR raised this concern on that PR; extracted here to keep scope clean.

## Test plan

- [ ] Visit an item page while API is healthy — normal render
- [ ] Simulate 5xx from API — should show "This item couldn't be loaded. Please try again." with HTTP 503
- [ ] Simulate transport error (bad API_URL env) — same error UI, HTTP 503
- [ ] Visit a nonexistent item ID — should still show Next.js 404 page (HTTP 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR improves error handling for the item detail page so transient upstream failures and transport errors surface an error UI and appropriate HTTP status instead of being treated as “not found.” Previously, upstream 5xx/transport failures returned { notFound: true } making pages appear permanently deleted during outages.

## Changes

- Error response handling in pages/item/[itemId].js (getServerSideProps):
  - API 404/410 → continue to return `{ notFound: true }` (HTTP 404).
  - API 429 or 5xx → set `context.res.statusCode = 503` and return `{ props: { url, item: null, errorState: true } }` to render an error UI.
  - Other non-OK responses → set `context.res.statusCode = 502` and return props with `errorState: true`.
  - Network/transport errors (caught in try/catch) → set `context.res.statusCode = 503`, redact any `api_key=` in logged messages, and return props with `item: null` and `errorState: true`.
- UI:
  - `ItemDetail` component now accepts an `errorState` prop and short-circuits rendering when `errorState || !item` to render an error state page (prevents null-reference crashes).
  - Adds `.errorMessage` CSS module class in components/ItemComponents/itemComponent.module.scss for centered, padded error text.
- Error logging:
  - Catch blocks now use safer extraction (optional chaining) and redact `api_key` values from error messages before logging.

## Security & infra impact

- Security: Improves credential safety by redacting `api_key` from logged error messages.
- No changes to environment variables or AWS Secrets Manager keys.
- No database migrations.
- No changes to shared infrastructure (CodePipeline, CodeBuild, ECS task definitions, IAM policies).
- No public-facing API response shape changes or new endpoints.

## Deployment / Operational notes

- Standard deployment is sufficient; no special pipeline trigger or ECS redeploy is required beyond normal release procedures.

## Tests / Checklist

Provided test plan covers:
- Normal render when API healthy.
- Simulated API 5xx → error UI and HTTP 503.
- Simulated transport error (bad API_URL) → error UI and HTTP 503.
- Nonexistent item ID → Next.js 404 (HTTP 404).

## Related

- Companion PR to #149 (search page error state). This PR extracts and focuses review concerns specific to the item page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->