### PR TITLE
Add .json and .raw metadata endpoints to item pages

### DIFF
--- a/components/ItemComponents/itemComponent.module.scss
+++ b/components/ItemComponents/itemComponent.module.scss
@@ -29,6 +29,35 @@
   background-color: $colderBackgroundColor;
 }
 
+.metadataLinks {
+  background-color: $colderBackgroundColor;
+  border-radius: 3px;
+  margin-bottom: 0.5rem;
+  padding: 0.75rem;
+  width: 100%;
+
+  h2 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+  }
+
+  ul {
+    font-size: 0.9rem;
+    margin: 0;
+    padding-left: 1.25rem;
+  }
+
+  a, a:visited {
+    color: $subLinkColor;
+  }
+
+  a:hover,
+  a:focus-visible {
+    color: $subLinkColorHover;
+  }
+}
+
 .notFound {
   margin: 0 0 3rem;
 }

--- a/constants/items.js
+++ b/constants/items.js
@@ -1,2 +1,3 @@
 export const API_ENDPOINT = "/api/dpla/items";
 export const THUMBNAIL_ENDPOINT = "/thumb";
+export const DPLA_ITEM_ID_REGEX = /^[0-9a-f]{32}$/;

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,16 @@
 module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: "/item/:id([0-9a-f]{32}).json",
+        destination: "/api/items/:id?single=1",
+      },
+      {
+        source: "/item/:id([0-9a-f]{32}).raw",
+        destination: "/api/items/raw/:id",
+      },
+    ];
+  },
   webpack: (config, { isServer }) => {
     // Fixes npm packages that depend on `fs` module
     if (!isServer) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "react-ga4": "^2.1.0",
         "react-markdown": "^4.3.1",
         "react-slick": "^0.30.0",
-        "sass": "^1.26.10"
+        "sass": "^1.26.10",
+        "xml-formatter": "^3.7.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
@@ -2475,6 +2476,27 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
+    },
+    "node_modules/xml-formatter": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-3.7.0.tgz",
+      "integrity": "sha512-+8qTc3zv2UcJ1v9IsSIce37Dl4MQG14Cp7tWrwmy202UaI1wqRukw5QMX1JHsV+DX64yw77EgGsj2s5wGvuMbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-parser-xo": "^4.1.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/xml-parser-xo": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-4.1.5.tgz",
+      "integrity": "sha512-TxyRxk9sTOUg3glxSIY6f0nfuqRll2OEF8TspLgh5mZkLuBgheCn3zClcDSGJ58TvNmiwyCCuat4UajPud/5Og==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "nuke": "npm run clean && npm i && npm run build && npm run start"
   },
   "dependencies": {
+    "@babel/runtime": "^7.26.10",
     "babel-plugin-inline-react-svg": "^1.1.1",
     "babel-plugin-module-resolver": "^4.0.0",
     "localforage": "^1.9.0",
@@ -25,7 +26,7 @@
     "react-markdown": "^4.3.1",
     "react-slick": "^0.30.0",
     "sass": "^1.26.10",
-    "@babel/runtime": "^7.26.10"
+    "xml-formatter": "^3.7.0"
   },
   "overrides": {
     "@babel/runtime": "^7.26.10",

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -1,0 +1,69 @@
+import { pipeline } from "stream/promises";
+import { Readable } from "stream";
+import { DPLA_ITEM_ID_REGEX } from "constants/items";
+
+export default async function handler(req, res) {
+    if (req.method !== "GET") {
+        res.setHeader("Allow", "GET");
+        res.status(405).json({ error: "Method not allowed" });
+        return;
+    }
+
+    const { idListString, single } = req.query;
+    const idList = idListString ? idListString.split(",") : [];
+    const validIds = idList.filter(id => !!id && DPLA_ITEM_ID_REGEX.test(id));
+
+    if (validIds.length === 0) {
+        res.status(404).json({ error: "Not found." });
+        return;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8000);
+
+    try {
+        const apiVersion = process.env.API_VERSION || "v2";
+        const baseUrl = new URL(`${process.env.API_URL}/${apiVersion}/items/`);
+        baseUrl.searchParams.set("api_key", process.env.API_KEY);
+        baseUrl.pathname += validIds.join(",");
+        const fetchRes = await fetch(baseUrl, {
+            signal: controller.signal,
+            headers: { "DPLA-INTERNAL-ACCESS": process.env.DPLA_INTERNAL_ACCESS },
+        });
+        if (fetchRes.ok) {
+            if (single === "1") {
+                const data = await fetchRes.json();
+                const doc = data?.docs?.[0];
+                if (!doc) {
+                    res.status(404).json({ error: "Not found." });
+                    return;
+                }
+                res.setHeader("Content-Type", "application/json; charset=utf-8");
+                res.setHeader("Cache-Control", "public, max-age=86400");
+                res.status(200).send(JSON.stringify(doc, null, 2));
+            } else {
+                const contentType = fetchRes.headers.get("Content-Type") || "application/json; charset=utf-8";
+                res.setHeader("Cache-Control", "public, max-age=86400");
+                res.setHeader("Content-Type", contentType);
+                res.status(200);
+                await pipeline(Readable.fromWeb(fetchRes.body), res);
+            }
+        } else {
+            fetchRes.body?.cancel?.().catch(() => {});
+            if (fetchRes.status === 404) {
+                res.status(404).json({ error: "Not found." });
+            } else {
+                res.status(fetchRes.status).json({ error: "Upstream service error." });
+            }
+        }
+    } catch (err) {
+        if (err?.name === "AbortError") {
+            res.status(504).json({ error: "Upstream timeout." });
+            return;
+        }
+        console.error("Error proxying request to DPLA API.", err);
+        res.status(502).json({ error: "Upstream service error." });
+    } finally {
+        clearTimeout(timeout);
+    }
+}

--- a/pages/api/items/[idListString].js
+++ b/pages/api/items/[idListString].js
@@ -10,8 +10,11 @@ export default async function handler(req, res) {
     }
 
     const { idListString, single } = req.query;
-    const idList = idListString ? idListString.split(",") : [];
-    const validIds = idList.filter(id => !!id && DPLA_ITEM_ID_REGEX.test(id));
+    if (typeof idListString !== "string") {
+        res.status(404).json({ error: "Not found." });
+        return;
+    }
+    const validIds = idListString.split(",").filter(id => !!id && DPLA_ITEM_ID_REGEX.test(id));
 
     if (validIds.length === 0) {
         res.status(404).json({ error: "Not found." });

--- a/pages/api/items/raw/[id].js
+++ b/pages/api/items/raw/[id].js
@@ -1,0 +1,80 @@
+import xmlFormat from "xml-formatter";
+import { DPLA_ITEM_ID_REGEX } from "constants/items";
+
+export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    res.status(405).send("Method not allowed.");
+    return;
+  }
+
+  const { id } = req.query;
+
+  if (typeof id !== "string" || !DPLA_ITEM_ID_REGEX.test(id)) {
+    res.status(404).send("Not found.");
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+
+  try {
+    const apiVersion = process.env.API_VERSION || "v2";
+    const url = new URL(`${process.env.API_URL}/${apiVersion}/items/${id}`);
+    url.searchParams.set("api_key", process.env.API_KEY);
+    const fetchRes = await fetch(url, {
+      signal: controller.signal,
+      headers: { "DPLA-INTERNAL-ACCESS": process.env.DPLA_INTERNAL_ACCESS },
+    });
+
+    if (!fetchRes.ok) {
+      fetchRes.body?.cancel?.().catch(() => {});
+      if (fetchRes.status === 404) {
+        res.status(404).send("Not found.");
+      } else {
+        res.status(fetchRes.status).send("Upstream error.");
+      }
+      return;
+    }
+
+    const data = await fetchRes.json();
+    const stringValue = data?.docs?.[0]?.originalRecord?.stringValue;
+
+    if (!stringValue) {
+      res.status(404).send("Not found.");
+      return;
+    }
+
+    const trimmed = stringValue.trim();
+
+    if (!trimmed) {
+      res.status(404).send("Not found.");
+      return;
+    }
+
+    let contentType, formatted;
+    if (trimmed.startsWith("<")) {
+      contentType = "text/xml; charset=utf-8";
+      formatted = xmlFormat(trimmed, {
+        indentation: "  ",
+        collapseContent: true,
+        lineSeparator: "\n",
+      });
+    } else {
+      contentType = "application/json; charset=utf-8";
+      formatted = JSON.stringify(JSON.parse(trimmed), null, 2);
+    }
+    res.setHeader("Content-Type", contentType);
+    res.setHeader("Cache-Control", "public, max-age=86400");
+    res.status(200).send(formatted);
+  } catch (err) {
+    if (err?.name === "AbortError") {
+      res.status(504).send("Upstream timeout.");
+      return;
+    }
+    console.error("Error fetching raw item record.", { id, name: err?.name, message: err?.message });
+    res.status(502).send("Upstream error.");
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -56,6 +56,15 @@ const ItemDetail = ({url, item, errorState}) => {
          className={`container ${css.contentWrapper}`}
        >
          <Content item={item} url={url} />
+         <div className={css.faveAndCiteButtons}>
+           <div className={css.metadataLinks}>
+             <h2>Metadata</h2>
+             <ul>
+               <li><a href={`/item/${item.id}.raw`}>Original record</a></li>
+               <li><a href={`/item/${item.id}.json`}>Enriched JSON-LD</a></li>
+             </ul>
+           </div>
+         </div>
       </main>
 
     </MainLayout>


### PR DESCRIPTION
## Summary

Port of dpla-frontend PRs #1452, #1453, #1454, and #1455 — adds developer-accessible structured data endpoints to every item page.

- **`/item/:id.json`** — Pretty-printed enriched JSON-LD (the full DPLA API document for the item)
- **`/item/:id.raw`** — Formatted original record from the contributing institution (XML or JSON, pretty-printed)
- **"Metadata" widget** on the item detail page with links to both endpoints
- `DPLA_ITEM_ID_REGEX` added to `constants/items.js` for request validation in both API routes
- `xml-formatter` added as a dependency for pretty-printing XML records

Both endpoints validate the item ID with a 32-char hex regex, set `Cache-Control: public, max-age=86400`, use an 8-second `AbortController` timeout, and propagate upstream error statuses accurately (no collapsing upstream 5xx into 404).

The API routes are adapted from dpla-frontend to use BWS's `API_VERSION` env var and `DPLA-INTERNAL-ACCESS` header.

## Test plan

- [ ] Visit `/item/<32-char-id>.json` — confirm pretty-printed JSON response with `Content-Type: application/json; charset=utf-8`
- [ ] Visit `/item/<32-char-id>.raw` — confirm formatted XML (or JSON) with correct Content-Type
- [ ] Visit `/item/<32-char-id>` — confirm "Metadata" widget is visible in the sidebar with both links
- [ ] Visit `/item/notanid.json` and `/item/notanid.raw` — confirm 404
- [ ] Visit `/item/<valid-but-nonexistent-id>.json` — confirm 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds two developer-accessible metadata endpoints and a "Metadata" UI widget on item detail pages.

New endpoints
- GET /item/:id.json — returns the enriched JSON-LD (full DPLA API document for the item), pretty-printed
- GET /item/:id.raw — returns the contributing institution's original record (XML or JSON), formatted and pretty-printed

Key changes
- Routing: added rewrites in next.config.js to map /item/:id.json → /api/items/:id?single=1 and /item/:id.raw → /api/items/raw/:id
- API routes: new Next.js handlers
  - pages/api/items/[idListString].js — supports fetching one-or-more items from upstream; validates idListString as string, filters IDs using DPLA_ITEM_ID_REGEX, supports single=1 to return a single document, proxies upstream content types, streams large responses, mirrors upstream non-404 status codes, and sets Cache-Control: public, max-age=86400
  - pages/api/items/raw/[id].js — validates id, fetches upstream item, extracts data.docs[0].originalRecord.stringValue, detects XML vs JSON, pretty-prints using xml-formatter for XML (new dependency) or JSON.stringify for JSON, and sets Cache-Control: public, max-age=86400
- ID validation: added exported DPLA_ITEM_ID_REGEX (^[0-9a-f]{32}$) in constants/items.js and guards for Next.js query param string | string[] cases
- UI: added "Metadata" widget on pages/item/[itemId].js with links to .raw and .json endpoints
- Styling: added .metadataLinks class in components/ItemComponents/itemComponent.module.scss
- Dependencies: added xml-formatter v3.7.0 to package.json
- Behavior & robustness:
  - Both endpoints use an 8-second AbortController timeout
  - Upstream 404s return 404; other upstream errors are propagated (do not collapse 5xx into 404)
  - Content-Type from upstream is preserved when proxying; .raw endpoint detects and returns appropriate content types

Deployment / infrastructure / security notes
- Requires a standard Next.js rebuild/deploy (the next.config.js rewrites and new dependency require deploying a new build); trigger your usual pipeline/ECS deployment to make routes live.
- No new environment variables or AWS Secrets Manager keys were introduced. The routes use existing env vars: API_URL, API_VERSION (newly referenced explicitly in the routes), API_KEY, and the existing DPLA-INTERNAL-ACCESS header value. Confirm those env vars/secret values are present in the deployment environment.
- No database migrations or changes to shared infra (CodePipeline, CodeBuild, ECS task definitions, IAM) are included in this PR.
- Security: the endpoints send the DPLA-INTERNAL-ACCESS header to upstream and accept external IDs; ID validation is enforced with DPLA_ITEM_ID_REGEX. Upstream errors and timeouts are propagated appropriately. Review access control for these developer-facing endpoints if sensitive upstream data must remain restricted.

Tests / manual validation
- Test plan included: manual checks for endpoint responses and content types, widget visibility on item pages, handling of invalid IDs, and correct 404 behavior for nonexistent IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->