### PR TITLE
Validate item ID format before calling upstream API

### DIFF
--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -12,6 +12,7 @@ import {
   joinIfArray,
   getItemThumbnail,
 } from "lib";
+import { DPLA_ITEM_ID_REGEX } from "constants/items";
 
 import css from "components/ItemComponents/itemComponent.module.scss";
 
@@ -73,6 +74,9 @@ const ItemDetail = ({url, item, errorState}) => {
 
 export async function getServerSideProps(context) {
   const itemId = context.params.itemId;
+  if (typeof itemId !== "string" || !DPLA_ITEM_ID_REGEX.test(itemId)) {
+    return { notFound: true };
+  }
   const url = getCurrentFullUrl(context.req);
   try {
     const apiVersion = process.env.API_VERSION || "v2";


### PR DESCRIPTION
## Summary

- Without this guard, requests like `/item/notanid.json` fall through the `next.config.js` rewrite (which correctly rejects non-hex IDs via the `([0-9a-f]{32})` pattern) and land on the item page handler, which calls the upstream API with an invalid ID and propagates a 502
- Adds a `DPLA_ITEM_ID_REGEX` check at the top of `getServerSideProps` — returns `notFound: true` (HTTP 404) immediately for any structurally invalid ID, before any network call is made

Spotted during post-deploy verification of #152.

## Test plan

- [ ] `/item/notanid` — returns 404
- [ ] `/item/notanid.json` — returns 404
- [ ] `/item/notanid.raw` — returns 404
- [ ] `/item/<valid-32-char-hex-id>` — item page still loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-level Summary

This PR adds upfront validation of the item ID format in `pages/item/[itemId].js` to prevent invalid IDs from reaching the upstream DPLA API. Before any network call, `getServerSideProps` now checks that the `itemId` is a string and matches the `DPLA_ITEM_ID_REGEX` pattern (32 hexadecimal characters). If validation fails, the page immediately returns `{ notFound: true }` (HTTP 404) instead of attempting an API request that would fail with a 502 error.

**Rationale**: Requests with invalid item IDs (e.g., `/item/notanid.json`) currently bypass the rewrite rule in `next.config.js` (which enforces a `[0-9a-f]{32}` pattern) and reach the item page handler, which then makes an API call with the invalid ID and returns a 502. This fix prevents that by rejecting structurally invalid IDs early.

## Changes

- **pages/item/[itemId].js**: Added ID format validation at the top of `getServerSideProps` (4 lines added)

## Testing

The PR verifies the following scenarios:
- `/item/notanid` → returns 404
- `/item/notanid.json` → returns 404
- `/item/notanid.raw` → returns 404
- `/item/<valid-32-char-hex-id>` → item page loads normally

**No special deployment considerations apply** — no environment variable changes, infrastructure changes, database migrations, or public API modifications are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->