### PR TITLE
Fix search page title showing "null | Search Results" for empty query

### DIFF
--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -91,10 +91,12 @@ const Search = ({ results, numberOfActiveFacets, pageCount, currentPage, pageSiz
 
 export async function getServerSideProps(context) {
     const query = context.query;
+    const rawQ = Array.isArray(query.q) ? query.q[0] : query.q;
+    const normalizedQ = rawQ?.trim() || undefined;
     const sort_order = query.sort_order || "";
 
-    const q = query.q
-        ? encodeURIComponent(query.q.trim())
+    const q = normalizedQ
+        ? encodeURIComponent(normalizedQ)
             .replace(/'/g, "%27")
             .replace(/"/g, "%22")
         : "";
@@ -151,7 +153,7 @@ export async function getServerSideProps(context) {
         currentPage: Number(page),
         pageCount: 0,
         pageSize: page_size,
-        query: query.q?.trim() || undefined,
+        query: normalizedQ,
         errorState: false
     };
 
@@ -233,7 +235,7 @@ export async function getServerSideProps(context) {
             currentPage: Number(page),
             pageCount,
             pageSize: page_size,
-            query: query.q?.trim() || undefined,
+            query: normalizedQ,
             errorState: false
         }
     };

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -45,10 +45,10 @@ const Search = ({ results, numberOfActiveFacets, pageCount, currentPage, pageSiz
     return (
         <MainLayout>
             <BWSHead
-                pageTitle={query === undefined ?
+                pageTitle={!query ?
                     "Search Results | DPLA" :
                     `${query} | Search Results | DPLA`}
-                pageDescription={query === undefined ?
+                pageDescription={!query ?
                     "Search results" :
                     `Search results for "${query}"`}
             />
@@ -151,7 +151,7 @@ export async function getServerSideProps(context) {
         currentPage: Number(page),
         pageCount: 0,
         pageSize: page_size,
-        query: query.q || null,
+        query: query.q?.trim() || undefined,
         errorState: false
     };
 
@@ -233,7 +233,7 @@ export async function getServerSideProps(context) {
             currentPage: Number(page),
             pageCount,
             pageSize: page_size,
-            query: query.q || null,
+            query: query.q?.trim() || undefined,
             errorState: false
         }
     };


### PR DESCRIPTION
## Summary

- When navigating to \`/search?q=\` (empty query), the page title rendered as **"null | Search Results | DPLA"** instead of **"Search Results | DPLA"**
- Root cause: \`getServerSideProps\` passed \`query.q || null\` to the component, so an empty \`?q=\` produced a \`null\` prop; the component only guarded against \`=== undefined\`, so \`null\` fell through into the template literal and was coerced to the string \`"null"\`
- Fix: pass \`query.q?.trim() || undefined\` so blank/whitespace queries yield \`undefined\`, and broaden the component guard from \`=== undefined\` to \`!query\` so both \`null\` and \`undefined\` are handled

## Test plan

- [ ] Navigate to \`/search?q=\` — page title should be "Search Results | DPLA"
- [ ] Navigate to \`/search?q=suffrage\` — page title should be "suffrage | Search Results | DPLA"
- [ ] Navigate to \`/search?q=   \` (whitespace only) — page title should be "Search Results | DPLA"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix search page title showing "null | Search Results" for empty query

Fixes a bug where navigating to /search?q= (empty search query) rendered the page title as "null | Search Results | DPLA" instead of the expected "Search Results | DPLA".

### Changes
- pages/search/index.js
  - Normalize incoming query.q in getServerSideProps:
    - If query.q is an array (e.g. ?q=a&q=b) use the first element.
    - Trim whitespace and convert empty or whitespace-only values to undefined (const normalizedQ = rawQ?.trim() || undefined).
    - Use normalizedQ for both the encoded search parameter and the returned props.query (previously returned query.q || null).
  - Broaden client-side guard for rendering head/title/description from strict (query === undefined) to falsy (!query) so null/undefined/empty-string are treated as “no query”.
  - Ensure .trim() is not called on arrays (avoids TypeError during SSR) by centralizing normalization.

### Behavior / Test plan
- /search?q= → Title: "Search Results | DPLA"
- /search?q=   (whitespace only) → Title: "Search Results | DPLA"
- /search?q=suffrage → Title: "suffrage | Search Results | DPLA"

### Side effects / notable details
- No changes to CI/CD, deployment, environment variables, secrets, database migrations, or shared infrastructure.
- No changes to public API shapes or endpoints.
- No security-sensitive changes introduced (no new credential handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->