### PR TITLE
Port search error UI and structured data from dpla-frontend

### DIFF
--- a/components/BWSHead/index.js
+++ b/components/BWSHead/index.js
@@ -1,6 +1,7 @@
 import React from "react"
 import Head from "next/head"
 import { useRouter } from 'next/router'
+import { SITE_URL } from "constants/site"
 
 const BWSHead = (props) => {
   const router = useRouter()
@@ -19,8 +20,7 @@ const BWSHead = (props) => {
 
   const defaultImageUrl = "/static/logo/dpla_bws-logo-color-nav.png"
 
-  const baseUrl = 'https://blackwomenssuffrage.dp.la';
-  const currentUrl = canonicalUrl || `${baseUrl}${router.asPath}`
+  const currentUrl = canonicalUrl || `${SITE_URL}${router.asPath}`
 
   return (
     <div>
@@ -53,7 +53,7 @@ const BWSHead = (props) => {
         <link rel='canonical' href={currentUrl} />
 
         <meta name='twitter:card' content='summary' />
-        <meta name='twitter:url' content={currentUrl || baseUrl}/>
+        <meta name='twitter:url' content={currentUrl || SITE_URL}/>
         <meta name='twitter:title' content="Black Women's Suffrage Collection" />
         <meta name='twitter:description' content={pageDescription || defaultDescription} />
         <meta name='twitter:image' content={pageImage || defaultImageUrl} />
@@ -65,7 +65,7 @@ const BWSHead = (props) => {
         <meta property='og:title' content={pageTitle || defaultPageTitle} />
         <meta property='og:description' content={pageDescription || defaultDescription} />
         <meta property='og:site_name' content={defaultPageTitle} />
-        <meta property='og:url' content={currentUrl || baseUrl}/>
+        <meta property='og:url' content={currentUrl || SITE_URL}/>
         <meta property='og:image' content={pageImage || defaultImageUrl} />
 
       </Head>

--- a/components/BWSHead/index.js
+++ b/components/BWSHead/index.js
@@ -53,7 +53,7 @@ const BWSHead = (props) => {
         <link rel='canonical' href={currentUrl} />
 
         <meta name='twitter:card' content='summary' />
-        <meta name='twitter:url' content={currentUrl || SITE_URL}/>
+        <meta name='twitter:url' content={currentUrl}/>
         <meta name='twitter:title' content="Black Women's Suffrage Collection" />
         <meta name='twitter:description' content={pageDescription || defaultDescription} />
         <meta name='twitter:image' content={pageImage || defaultImageUrl} />
@@ -65,7 +65,7 @@ const BWSHead = (props) => {
         <meta property='og:title' content={pageTitle || defaultPageTitle} />
         <meta property='og:description' content={pageDescription || defaultDescription} />
         <meta property='og:site_name' content={defaultPageTitle} />
-        <meta property='og:url' content={currentUrl || SITE_URL}/>
+        <meta property='og:url' content={currentUrl}/>
         <meta property='og:image' content={pageImage || defaultImageUrl} />
 
       </Head>

--- a/components/SearchPage/SearchError.js
+++ b/components/SearchPage/SearchError.js
@@ -1,0 +1,37 @@
+import React from "react";
+import Link from "next/link";
+import Button from "components/shared/Button";
+import css from "./SearchError.module.scss";
+
+function SearchError() {
+  return (
+    <div className={`container ${css.searchError}`}>
+      <h1>Search is temporarily unavailable.</h1>
+      <p>
+        We&rsquo;re having trouble connecting to our search service &mdash; this
+        is on our end, not yours.
+      </p>
+      <Button type="primary" onClick={() => window.location.reload()}>
+        Try again
+      </Button>
+      <p className={css.statusLink}>
+        Check our{" "}
+        <a href="https://status.dp.la" target="_blank" rel="noreferrer">
+          status page
+        </a>{" "}
+        to see if there&rsquo;s a known issue.
+      </p>
+      <p>While search is down, you can still:</p>
+      <ul className={css.alternativeLinks}>
+        <li>
+          Browse our <Link href="/collections">collections</Link>
+        </li>
+        <li>
+          Explore our <Link href="/key-figures">key figures</Link>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+export default SearchError;

--- a/components/SearchPage/SearchError.js
+++ b/components/SearchPage/SearchError.js
@@ -1,17 +1,23 @@
 import React from "react";
 import Link from "next/link";
 import Button from "components/shared/Button";
+import PageBanner from "shared/PageBanner";
 import css from "./SearchError.module.scss";
 
 function SearchError() {
   return (
-    <div className={`container ${css.searchError}`}>
-      <h1>Search is temporarily unavailable.</h1>
+    <>
+      <PageBanner
+        title="SEARCH ERROR"
+        text="Search is temporarily unavailable."
+      />
+      <div className={`container ${css.searchError}`}>
       <p>
         We&rsquo;re having trouble connecting to our search service &mdash; this
         is on our end, not yours.
       </p>
-      <Button type="primary" onClick={() => window.location.reload()}>
+      <br />
+      <Button type="primary" size="large" fitContent onClick={() => window.location.reload()}>
         Try again
       </Button>
       <p className={css.statusLink}>
@@ -30,7 +36,8 @@ function SearchError() {
           Explore our <Link href="/key-figures">key figures</Link>
         </li>
       </ul>
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/components/SearchPage/SearchError.module.scss
+++ b/components/SearchPage/SearchError.module.scss
@@ -1,0 +1,25 @@
+.searchError {
+  margin-bottom: 10rem;
+  margin-top: 5rem;
+  text-align: center;
+}
+
+.searchError h1 {
+  padding-bottom: 0.8rem;
+}
+
+.statusLink {
+  margin-top: 1.5rem;
+}
+
+.alternativeLinks {
+  display: inline-block;
+  list-style: none;
+  margin-top: 0.5rem;
+  padding: 0;
+  text-align: left;
+}
+
+.alternativeLinks li::before {
+  content: "→ ";
+}

--- a/components/SearchPage/SearchError.module.scss
+++ b/components/SearchPage/SearchError.module.scss
@@ -1,6 +1,7 @@
 .searchError {
-  margin-bottom: 10rem;
-  margin-top: 5rem;
+  margin-bottom: 5rem;
+  margin-top: 1rem;
+  padding: 1.5rem;
   text-align: center;
 }
 

--- a/components/shared/BreadcrumbJsonLd/index.js
+++ b/components/shared/BreadcrumbJsonLd/index.js
@@ -3,7 +3,7 @@ import { SITE_URL } from "constants/site";
 
 function resolveUrl(url) {
   if (!url) return null;
-  if (typeof url === "string") return SITE_URL + url;
+  if (typeof url === "string") return SITE_URL + (url.startsWith("/") ? url : `/${url}`);
   if (url.pathname) return SITE_URL + url.pathname;
   return null;
 }

--- a/components/shared/BreadcrumbJsonLd/index.js
+++ b/components/shared/BreadcrumbJsonLd/index.js
@@ -1,0 +1,39 @@
+import React from "react";
+import { SITE_URL } from "constants/site";
+
+function resolveUrl(url) {
+  if (!url) return null;
+  if (typeof url === "string") return SITE_URL + url;
+  if (url.pathname) return SITE_URL + url.pathname;
+  return null;
+}
+
+function BreadcrumbJsonLd({ breadcrumbs }) {
+  if (!Array.isArray(breadcrumbs) || breadcrumbs.length === 0) return null;
+
+  const itemListElement = breadcrumbs.map((breadcrumb, index) => {
+    const href = resolveUrl(breadcrumb.url);
+    const entry = {
+      "@type": "ListItem",
+      position: index + 1,
+      name: breadcrumb.title,
+    };
+    if (href) entry.item = href;
+    return entry;
+  });
+
+  const ld = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement,
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(ld).replace(/</g, "\\u003c") }}
+    />
+  );
+}
+
+export default BreadcrumbJsonLd;

--- a/components/shared/Breadcrumbs/Breadcrumbs.module.scss
+++ b/components/shared/Breadcrumbs/Breadcrumbs.module.scss
@@ -34,7 +34,6 @@
   align-items: center;
   display: flex;
   position: relative;
-  padding-bottom: 0.3em;
 
   &:after {
     content: "";

--- a/components/shared/Button/Button.module.scss
+++ b/components/shared/Button/Button.module.scss
@@ -74,6 +74,12 @@ $padding: 1rem;
   }
 }
 
+/* Widths */
+
+.buttonFitContent {
+  width: fit-content;
+}
+
 /* Sizes */
 
 .buttonLarge {

--- a/components/shared/Button/index.js
+++ b/components/shared/Button/index.js
@@ -21,6 +21,7 @@ const Button = ({
   title,
   type,
   state,
+  fitContent = false,
   mustSubmit = false,
   name,
   disabled,
@@ -70,6 +71,10 @@ const Button = ({
     case "active":
       buttonClasses = `${buttonClasses} ${css.active}`;
       break;
+  }
+
+  if (fitContent) {
+    buttonClasses = `${buttonClasses} ${css.buttonFitContent}`;
   }
 
   let linkProps = {};

--- a/constants/site.js
+++ b/constants/site.js
@@ -1,5 +1,6 @@
 export const GA_TRACKING_ID = "UA-28197764-11";
 export const SITE_TAG = "blackwomensuffrage";
+export const SITE_URL = "https://blackwomenssuffrage.dp.la";
 
 export const UNTITLED_TEXT = "Untitled";
 

--- a/pages/api/sitemap.js
+++ b/pages/api/sitemap.js
@@ -1,8 +1,9 @@
 import { keyFigures } from "../../constants/key-figures";
 import {timelineOptions} from "../../constants/timeline-options";
 import * as fs from "fs";
+import { SITE_URL } from "../../constants/site";
 
-const absoluteLink = (path) => { return `https://blackwomenssuffrage.dp.la${path}` }
+const absoluteLink = (path) => { return `${SITE_URL}${path}` }
 
 const buildEntry = (link, date) => {
     return `<url>

--- a/pages/collections/[colId]/[colItemId].js
+++ b/pages/collections/[colId]/[colItemId].js
@@ -7,6 +7,8 @@ import path from 'path'
 import { collections } from "constants/collections"
 import BWSHead from "components/BWSHead"
 import BreadcrumbsModule from "components/CollectionsPage/BreadcrumbsModule"
+import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd"
+import { joinIfArray } from "lib"
 
 function CollectionItem({ item, nextItem, prevItem, amountOfItems, currentItemNumber }) {
   return (
@@ -22,17 +24,16 @@ function CollectionItem({ item, nextItem, prevItem, amountOfItems, currentItemNu
       />
       <BreadcrumbsModule
         breadcrumbs={[
-          {
-            title: "Collections",
-            url: "/collections"
-          },
-          {
-            title: item.colName,
-            url: "/collections/" + item.colId
-          },
-          {
-            title: item.title.join(", ")
-          }
+          { title: "Collections", url: "/collections" },
+          { title: item.colName, url: "/collections/" + item.colId },
+          { title: joinIfArray(item.title) },
+        ]}
+      />
+      <BreadcrumbJsonLd
+        breadcrumbs={[
+          { title: "Collections", url: "/collections" },
+          { title: item.colName, url: "/collections/" + item.colId },
+          { title: joinIfArray(item.title) },
         ]}
       />
       <ItemView 

--- a/pages/collections/[colId]/index.js
+++ b/pages/collections/[colId]/index.js
@@ -10,6 +10,11 @@ import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd"
 
 function Collection({ collection, items }) {
 
+  const baseBreadcrumbs = [
+    { title: "Collections", path: "/collections" },
+    { title: collection.name },
+  ];
+
   return (
       <MainLayout
         className="main"
@@ -22,16 +27,10 @@ function Collection({ collection, items }) {
           pageImageCaption={collection.name}
         />
         <BreadcrumbsModule
-            breadcrumbs={[
-              { title: "Collections", url: { pathname: "/collections" } },
-              { title: collection.name },
-            ]}
+            breadcrumbs={baseBreadcrumbs.map(b => ({ title: b.title, url: b.path ? { pathname: b.path } : undefined }))}
           />
         <BreadcrumbJsonLd
-          breadcrumbs={[
-            { title: "Collections", url: "/collections" },
-            { title: collection.name },
-          ]}
+          breadcrumbs={baseBreadcrumbs.map(b => ({ title: b.title, url: b.path }))}
         />
         <ItemList collection={ collection } items={ items } />
       </MainLayout>

--- a/pages/collections/[colId]/index.js
+++ b/pages/collections/[colId]/index.js
@@ -13,7 +13,7 @@ function Collection({ collection, items }) {
 
   const baseBreadcrumbs = [
     { title: "Collections", path: "/collections" },
-    { title: collection.name },
+    { title: collection.name, path: `/collections/${collection.colId}` },
   ];
 
   const normalizedBreadcrumbs = baseBreadcrumbs.map(b => ({

--- a/pages/collections/[colId]/index.js
+++ b/pages/collections/[colId]/index.js
@@ -7,6 +7,7 @@ import { collections } from "constants/collections"
 import BWSHead from "components/BWSHead";
 import BreadcrumbsModule from "components/CollectionsPage/BreadcrumbsModule"
 import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd"
+import { UNTITLED_TEXT } from "constants/site"
 
 function Collection({ collection, items }) {
 
@@ -14,6 +15,11 @@ function Collection({ collection, items }) {
     { title: "Collections", path: "/collections" },
     { title: collection.name },
   ];
+
+  const normalizedBreadcrumbs = baseBreadcrumbs.map(b => ({
+    ...b,
+    title: b.title || UNTITLED_TEXT,
+  }));
 
   return (
       <MainLayout
@@ -27,10 +33,10 @@ function Collection({ collection, items }) {
           pageImageCaption={collection.name}
         />
         <BreadcrumbsModule
-            breadcrumbs={baseBreadcrumbs.map(b => ({ title: b.title, url: b.path ? { pathname: b.path } : undefined }))}
+            breadcrumbs={normalizedBreadcrumbs.map(b => ({ title: b.title, url: b.path ? { pathname: b.path } : undefined }))}
           />
         <BreadcrumbJsonLd
-          breadcrumbs={baseBreadcrumbs.map(b => ({ title: b.title, url: b.path }))}
+          breadcrumbs={normalizedBreadcrumbs.map(b => ({ title: b.title, url: b.path }))}
         />
         <ItemList collection={ collection } items={ items } />
       </MainLayout>

--- a/pages/collections/[colId]/index.js
+++ b/pages/collections/[colId]/index.js
@@ -6,6 +6,7 @@ import path from 'path'
 import { collections } from "constants/collections"
 import BWSHead from "components/BWSHead";
 import BreadcrumbsModule from "components/CollectionsPage/BreadcrumbsModule"
+import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd"
 
 function Collection({ collection, items }) {
 
@@ -22,17 +23,16 @@ function Collection({ collection, items }) {
         />
         <BreadcrumbsModule
             breadcrumbs={[
-              {
-                title: "Collections",
-                url: {
-                  pathname: "/collections"
-                }
-              },
-              { 
-                title: collection.name
-              }
+              { title: "Collections", url: { pathname: "/collections" } },
+              { title: collection.name },
             ]}
           />
+        <BreadcrumbJsonLd
+          breadcrumbs={[
+            { title: "Collections", url: "/collections" },
+            { title: collection.name },
+          ]}
+        />
         <ItemList collection={ collection } items={ items } />
       </MainLayout>
   )

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,15 +2,34 @@ import React from "react"
 import MainLayout from "components/MainLayout"
 import HomePage from "components/HomePage"
 import BWSHead from "components/BWSHead";
+import { SITE_URL } from "constants/site";
+
+const WEBSITE_JSON_LD = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  url: SITE_URL,
+  potentialAction: {
+    "@type": "SearchAction",
+    target: {
+      "@type": "EntryPoint",
+      urlTemplate: `${SITE_URL}/search?q={search_term_string}`,
+    },
+    "query-input": "required name=search_term_string",
+  },
+}).replace(/</g, "\\u003c");
 
 const Home = () => {
   return (
       <MainLayout className="main" role="main">
-          <BWSHead 
-          pageTitle="Black Women's Suffrage | DPLA"
+          <BWSHead
+          pageTitle="Black Women’s Suffrage | DPLA"
           pageDescription="The Black Women’s Suffrage Digital Collection is a collaborative project to provide digital access to materials documenting the roles and experiences of Black Women in the Women’s Suffrage Movement and, more broadly, women’s rights, voting rights, and civic activism between the 1850s and 1960."
           pageImage="/static/graphic/home-page/home-graphic-body-1-mobile.png"
-          pageImageCaption="Images from the Black Women's Suffrage collection"
+          pageImageCaption="Images from the Black Women’s Suffrage collection"
+          />
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: WEBSITE_JSON_LD }}
           />
         <HomePage/>
       </MainLayout>

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -5,6 +5,7 @@ import BWSHead from "components/BWSHead";
 import MainLayout from "components/MainLayout";
 import CiteButton from "components/shared/CiteButton";
 import BreadcrumbsModule from "components/ItemComponents/BreadcrumbsModule";
+import BreadcrumbJsonLd from "components/shared/BreadcrumbJsonLd";
 import Content from "components/ItemComponents/Content";
 
 import {
@@ -40,15 +41,16 @@ const ItemDetail = ({url, item, errorState}) => {
       />
       <BreadcrumbsModule
         breadcrumbs={[
-          {
-            title: "All items",
-            url: {
-              pathname: "/search"
-            }
-          },
-          { title: joinIfArray(item.title), search: "" }
+          { title: "All items", url: { pathname: "/search" } },
+          { title: joinIfArray(item.title), search: "" },
         ]}
         route={url}
+      />
+      <BreadcrumbJsonLd
+        breadcrumbs={[
+          { title: "All items", url: "/search" },
+          { title: joinIfArray(item.title) },
+        ]}
       />
 
       <main

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -6,9 +6,8 @@ import OptionsBar from "components/SearchPage/OptionsBar";
 import FiltersList from "components/SearchPage/FiltersList";
 import MainContent from "components/SearchPage/MainContent";
 import MaxPageError from "components/SearchPage/MaxPageError";
+import SearchError from "components/SearchPage/SearchError";
 import BWSHead from "components/BWSHead";
-
-import css from "./search.module.scss";
 
 import {
     getItemThumbnail,
@@ -66,11 +65,7 @@ const Search = ({ results, numberOfActiveFacets, pageCount, currentPage, pageSiz
                 route={router}
                 facets={results.facets}
             />}
-            {errorState && (
-                <p className={css.errorMessage}>
-                    Search results couldn&apos;t be loaded. Please try again.
-                </p>
-            )}
+            {errorState && <SearchError />}
             {!errorState && currentPage <= MAX_PAGE_SIZE &&
             <MainContent
                 hideSidebar={!showSidebar}

--- a/pages/search/search.module.scss
+++ b/pages/search/search.module.scss
@@ -1,4 +1,0 @@
-.errorMessage {
-  text-align: center;
-  padding: 2rem;
-}


### PR DESCRIPTION
## Summary

Ports two dpla-frontend improvements that are directly applicable to this codebase:

- **SearchError component** — replaces the bare `<p>` error paragraph on search API failure with a proper error UI: friendly heading, "Try again" reload button, link to status.dp.la, and fallback navigation to Collections and Key Figures
- **schema.org structured data** — adds BreadcrumbList JSON-LD to item, collection, and collection-item pages; adds WebSite + SearchAction JSON-LD to the home page for Google sitelink searchbox eligibility

Also centralises `https://blackwomenssuffrage.dp.la` into `constants/site.js` as `SITE_URL`, removing four separate hardcoded copies from `BWSHead`, `pages/index.js`, `BreadcrumbJsonLd`, and `api/sitemap.js`.

## Test plan

- [ ] Simulate a search API failure and confirm the new SearchError UI renders (retry button, status link, Collections/Key Figures links)
- [ ] Confirm "Try again" button reloads the page
- [ ] Inspect page source on an item page, collection page, and home page and confirm valid JSON-LD `<script>` tags are present
- [ ] Validate structured data with Google's Rich Results Test or schema.org validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR ports the SearchError UI and schema.org structured-data support from dpla-frontend, and centralizes the site URL into a new constant. Changes are frontend-only; there are no infrastructure, build pipeline, environment variable, AWS Secrets Manager, or database migrations, and no public API response-shape or endpoint changes.

Operational / Security notes:
- No manual pipeline trigger, ECS redeploy, CodeBuild/CodePipeline, or IAM changes required.
- No new or removed environment variables or Secrets Manager keys.
- No database migrations.
- Security: JSON-LD output escapes '<' to mitigate injection risk. The SearchError UI includes an external link to https://status.dp.la and uses window.location.reload() for retry; these are standard client-side behaviors with no credential handling changes.

## Key Changes

### SearchError Component
- Adds components/SearchPage/SearchError.js and styles SearchError.module.scss.
- Replaces the plain <p> error message on the search page with a full error UI:
  - “SEARCH ERROR” heading and explanatory text
  - Primary “Try again” button that triggers a full page reload (window.location.reload())
  - Link to https://status.dp.la (opens in new tab)
  - Fallback navigation links to /collections and /key-figures
- Styling tweaks (padding, constrained retry button width, border-radius fix) included; Button component gained a fitContent prop and a .buttonFitContent class to support width: fit-content.

### Structured Data (JSON-LD)
- Adds components/shared/BreadcrumbJsonLd to emit BreadcrumbList JSON-LD for:
  - Item pages (pages/item/[itemId].js)
  - Collection pages (pages/collections/[colId]/index.js)
  - Collection item pages (pages/collections/[colId]/[colItemId].js)
- Adds WebSite + SearchAction JSON-LD to pages/index.js to provide a search URL template (supports Google sitelink searchbox eligibility).
- JSON-LD generation includes HTML escaping of '<' characters to reduce injection risk.
- Breadcrumb computation logic was deduplicated/refactored across affected pages; fixes applied for resolveUrl and title normalization to ensure consistent absolute URLs and defined titles in JSON-LD.

### Site URL Centralization
- New constants/site.js exports SITE_URL = "https://blackwomenssuffrage.dp.la".
- Replaces hardcoded domain occurrences in:
  - components/BWSHead/index.js (canonical/current URL fallback)
  - pages/index.js (WebSite/SearchAction URL template)
  - components/shared/BreadcrumbJsonLd/index.js (absolute breadcrumb URLs)
  - pages/api/sitemap.js (absolute sitemap links)

### Supporting Changes
- pages/search/index.js now renders the new SearchError component when errorState is true; removed the old local errorMessage class/usage.
- components/shared/Button/index.js: added fitContent prop and class handling to support width: fit-content styling.
- Minor CSS adjustments: removed bottom padding from Breadcrumbs styles; breadcrumb/title handling tweaked (joinIfArray used for item titles).
- Commit messages include fixes for resolveUrl and deduplicated breadcrumb title normalization.

## Test Recommendations
- Simulate search API failure to verify SearchError UI renders with retry button, status link, and fallback navigation.
- Confirm "Try again" button triggers a full page reload.
- Inspect page source for valid <script type="application/ld+json"> tags on home, collection, collection-item, and item pages.
- Validate structured data with Google Rich Results Test or schema.org validator.
- Confirm breadcrumb visuals and navigation remain correct after breadcrumb refactor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->