### PR TITLE
Fix SSR crash when item has null dataProvider (Contributing Institution)

### DIFF
--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -7,96 +7,100 @@ import { joinIfArray, readMyRights } from "lib";
 
 import css from "./Content.module.scss";
 
-const OtherMetadata = ({ item }) =>
-  <div className={css.otherMetadata}>
-    <dl className={css.contentDL}>
-      <ItemTermValuePair heading="Partner">
-        <FacetLink facet="partner" value={item.partner} />
-      </ItemTermValuePair>
+const OtherMetadata = ({ item }) => {
+  const rights = item.edmRights ? readMyRights(item.edmRights) : null;
+  return (
+    <div className={css.otherMetadata}>
+      <dl className={css.contentDL}>
+        <ItemTermValuePair heading="Partner">
+          <FacetLink facet="partner" value={item.partner} />
+        </ItemTermValuePair>
 
-      <ItemTermValuePair heading="Contributing Institution">
-        <FacetLink
-          facet="provider"
-          value={item.contributor.name}
-          facetLabel="contributing institution"
-        />
-      </ItemTermValuePair>
-      {item.intermediateProvider &&
-        <ItemTermValuePair heading="Supporting Institution">
-          <FacetLink facet="provider" value={item.intermediateProvider} />
-        </ItemTermValuePair>}
+        {item.contributor &&
+          <ItemTermValuePair heading="Contributing Institution">
+            <FacetLink
+              facet="provider"
+              value={item.contributor}
+              facetLabel="contributing institution"
+            />
+          </ItemTermValuePair>}
+        {item.intermediateProvider &&
+          <ItemTermValuePair heading="Supporting Institution">
+            <FacetLink facet="provider" value={item.intermediateProvider} />
+          </ItemTermValuePair>}
 
-      {item.subject &&
-        <ItemTermValuePair className={css.subjects} heading="Subjects">
-          {item.subject.map((subj, i, subjects) =>
-            <span key={i}>
-              <FacetLink facet="subject" value={subj.name} />
-              <br />
-            </span>
-          )}
-        </ItemTermValuePair>}
+        {item.subject &&
+          <ItemTermValuePair className={css.subjects} heading="Subjects">
+            {item.subject.map((subj, i) =>
+              <span key={subj?.name ?? i}>
+                <FacetLink facet="subject" value={subj?.name} />
+                <br />
+              </span>
+            )}
+          </ItemTermValuePair>}
 
-      {item.type &&
-        <ItemTermValuePair heading="Type">
-          {Array.isArray(item.type)
-            ? item.type.map((type, i, types) =>
-                <span key={i}>
-                  <FacetLink facet="type" value={type} /><br />
-                </span>
-              )
-            : <FacetLink facet="type" value={item.type} />}
-        </ItemTermValuePair>}
+        {item.type &&
+          <ItemTermValuePair heading="Type">
+            {Array.isArray(item.type)
+              ? item.type.map((type, i) =>
+                  <span key={i}>
+                    <FacetLink facet="type" value={type} /><br />
+                  </span>
+                )
+              : <FacetLink facet="type" value={item.type} />}
+          </ItemTermValuePair>}
 
-      {item.format &&
-        <ItemTermValuePair heading="Format">
-          {!Array.isArray(item.format)
-            ? <div>{item.format}</div>
-            : item.format.map((format, i, formats) =>
-                <div key={i}>{format}</div>
-              )}
-        </ItemTermValuePair>}
+        {item.format &&
+          <ItemTermValuePair heading="Format">
+            {!Array.isArray(item.format)
+              ? <div>{item.format}</div>
+              : item.format.map((format, i) =>
+                  <div key={i}>{format}</div>
+                )}
+          </ItemTermValuePair>}
 
-      <div className={css.divider}></div>
+        <div className={css.divider}></div>
 
-      {item.sourceUrl &&
-        <ItemTermValuePair heading="URL">
-          <a
-            className="link clickThrough external"
-            href={item.sourceUrl}
-            target="_blank"
-          >
-            {item.sourceUrl}
-          </a>
-        </ItemTermValuePair>}
+        {item.sourceUrl &&
+          <ItemTermValuePair heading="URL">
+            <a
+              className="link clickThrough external"
+              href={item.sourceUrl}
+              target="_blank"
+            >
+              {item.sourceUrl}
+            </a>
+          </ItemTermValuePair>}
 
-      {item.edmRights &&
-        readMyRights(item.edmRights) &&
-        <ItemTermValuePair heading="Standardized Rights Statement">
-          {readMyRights(item.edmRights).description}
-          {readMyRights(item.edmRights).description !== "" && <br />}
-          <a
-            href={item.edmRights}
-            className="link external"
-            rel="noopener noreferrer"
-          >
-            {item.edmRights}
-          </a>
-        </ItemTermValuePair>}
+        {rights &&
+          <ItemTermValuePair heading="Standardized Rights Statement">
+            {rights.description}
+            {rights.description !== "" && <br />}
+            <a
+              href={item.edmRights}
+              className="link external"
+              rel="noopener noreferrer"
+            >
+              {item.edmRights}
+            </a>
+          </ItemTermValuePair>}
 
-      {item.rights &&
-        <ItemTermValuePair heading="Rights">
-          <div
-            dangerouslySetInnerHTML={{
-              __html: joinIfArray(item.rights, "<br />")
-            }}
-          />
-        </ItemTermValuePair>}
+        {item.rights &&
+          <ItemTermValuePair heading="Rights">
+            <div
+              dangerouslySetInnerHTML={{
+                __html: joinIfArray(item.rights, "<br />")
+              }}
+            />
+          </ItemTermValuePair>}
 
-      {item.publisher &&
-        <ItemTermValuePair heading="Publisher">
-          {joinIfArray(item.publisher)}
-        </ItemTermValuePair>}
-    </dl>
-  </div>;
+        {item.publisher &&
+          <ItemTermValuePair heading="Publisher">
+            {joinIfArray(item.publisher)}
+          </ItemTermValuePair>}
+      </dl>
+    </div>
+  );
+};
 
 export default OtherMetadata;

--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -30,11 +30,13 @@ const OtherMetadata = ({ item }) => {
             <FacetLink facet="provider" value={item.intermediateProvider} />
           </ItemTermValuePair>}
 
-        {item.subject &&
+        {item.subject?.some(subj => subj?.name) &&
           <ItemTermValuePair className={css.subjects} heading="Subjects">
-            {item.subject.map((subj, i) =>
-              <span key={subj?.name ?? i}>
-                <FacetLink facet="subject" value={subj?.name} />
+            {item.subject
+             .filter(subj => subj?.name)
+             .map((subj, i) =>
+             <span key={subj.name ?? i}>
+               <FacetLink facet="subject" value={subj.name} />
                 <br />
               </span>
             )}

--- a/components/ItemComponents/Content/OtherMetadata.js
+++ b/components/ItemComponents/Content/OtherMetadata.js
@@ -12,9 +12,10 @@ const OtherMetadata = ({ item }) => {
   return (
     <div className={css.otherMetadata}>
       <dl className={css.contentDL}>
-        <ItemTermValuePair heading="Partner">
-          <FacetLink facet="partner" value={item.partner} />
-        </ItemTermValuePair>
+        {item.partner &&
+          <ItemTermValuePair heading="Partner">
+            <FacetLink facet="partner" value={item.partner} />
+          </ItemTermValuePair>}
 
         {item.contributor &&
           <ItemTermValuePair heading="Contributing Institution">

--- a/components/MainLayout/components/PageHeader/index.js
+++ b/components/MainLayout/components/PageHeader/index.js
@@ -22,23 +22,19 @@ class PageHeader extends React.Component {
             : ""} site-max-width`}
         >
           {(SITE_ENV === "user" || SITE_ENV === "pro") &&
-            <Link prefetch as="/" href={SITE_ENV === "user" ? "/" : "/pro"}>
-              <a className={css.logo} title="Home Page">
-                <dplaLogoWide className={css.logoImg} />
-              </a>
+            <Link prefetch as="/" href={SITE_ENV === "user" ? "/" : "/pro"} className={css.logo} title="Home Page">
+              <dplaLogoWide className={css.logoImg} />
             </Link>}
           {SITE_ENV === "local" &&
-            <Link prefetch href="/local" as="/">
-              <a className={`${css.logo} ${css.local}`} title="Home Page">
-                <img
-                  className={css.localLogo}
-                  alt={`${LOCALS[LOCAL_ID].name} Home`}
-                  src={`/static/local/${LOCALS[LOCAL_ID].theme}/${LOCALS[
-                    LOCAL_ID
-                  ].logo}`}
-                />
-                <span className={css.localText}>{LOCALS[LOCAL_ID].name}</span>
-              </a>
+            <Link prefetch href="/local" as="/" className={`${css.logo} ${css.local}`} title="Home Page">
+              <img
+                className={css.localLogo}
+                alt={`${LOCALS[LOCAL_ID].name} Home`}
+                src={`/static/local/${LOCALS[LOCAL_ID].theme}/${LOCALS[
+                  LOCAL_ID
+                ].logo}`}
+              />
+              <span className={css.localText}>{LOCALS[LOCAL_ID].name}</span>
             </Link>}
           {!hideSearchBar && <SearchBar />
           }

--- a/components/MainLayout/components/shared/LocalSidebar.js
+++ b/components/MainLayout/components/shared/LocalSidebar.js
@@ -5,10 +5,8 @@ import css from "components/shared/ContentPagesSidebar/Sidebar.scss";
 
 const SidebarLink = ({ route, isActive, title }) => {
   return (
-    <Link prefetch href={"/local" + route} as={route}>
-      <a className={`${css.link} ${isActive ? css.selected : ""}`}>
-        {title}
-      </a>
+    <Link prefetch href={"/local" + route} as={route} className={`${css.link} ${isActive ? css.selected : ""}`}>
+      {title}
     </Link>
   );
 };

--- a/components/MainLayout/components/shared/NavigationLocal.js
+++ b/components/MainLayout/components/shared/NavigationLocal.js
@@ -37,7 +37,7 @@ class NavigationLocal extends Component {
             <Link
               prefetch href={"/local/" + navItem.route}
               as={navItem.route}>
-              <a>{navItem.category}</a>
+              {navItem.category}
             </Link>
           </li>
         );
@@ -63,7 +63,7 @@ class NavigationLocal extends Component {
       blogHtml = (
           <li>
             <Link href={LOCALS[LOCAL_ID].externalLink}>
-              <a>Highlights Blog</a>
+              Highlights Blog
             </Link>
           </li>
       );
@@ -72,7 +72,7 @@ class NavigationLocal extends Component {
         <ul className={`${css.links} ${css.secondaryLinks}`}>
           <li>
             <Link href={LOCALS[LOCAL_ID].externalLink}>
-              <a href={LOCALS[LOCAL_ID].externalLink}>Visit {LOCALS[LOCAL_ID].name}</a>
+              Visit {LOCALS[LOCAL_ID].name}
             </Link>
           </li>
         </ul>
@@ -89,7 +89,7 @@ class NavigationLocal extends Component {
           {!isHome && (
             <li>
               <Link prefetch href="/local" as="/">
-                <a>Home</a>
+                Home
               </Link>
             </li>
           )}
@@ -98,27 +98,27 @@ class NavigationLocal extends Component {
           {LOCALS[LOCAL_ID].hasTerms && (
             <li>
               <Link prefetch href="/terms">
-                <a>Terms and Conditions</a>
+                Terms and Conditions
               </Link>
             </li>
           )}
           {LOCALS[LOCAL_ID].hasBrowseByPartner && (
             <li>
               <Link prefetch href="/browse-by-partner">
-                <a>Browse by Partner</a>
+                Browse by Partner
               </Link>
             </li>
           )}
           {LOCALS[LOCAL_ID].hasBrowseAll && (
             <li>
               <Link prefetch href="/search">
-                <a>Browse All</a>
+                Browse All
               </Link>
             </li>
           )}
           <li>
             <Link prefetch href="/lists">
-              <a>My Lists</a>
+              My Lists
             </Link>
           </li>
         </ul>

--- a/components/MainLayout/components/shared/NavigationPro.js
+++ b/components/MainLayout/components/shared/NavigationPro.js
@@ -9,24 +9,22 @@ const NavigationPro = ({ isHome, className, css }) =>
       {!isHome &&
         <li>
           <Link prefetch as="/" href="/pro">
-            <a>
-              Home
-            </a>
+            Home
           </Link>
         </li>}
       <li>
         <Link prefetch as="/hubs" href="/pro/wp/hubs?section=hubs">
-          <a>Hubs</a>
+          Hubs
         </Link>
       </li>
       <li>
         <Link prefetch as="/ebooks" href="/pro/wp/ebooks?section=ebooks">
-          <a>Ebooks</a>
+          Ebooks
         </Link>
       </li>
       <li>
         <Link prefetch as="/projects" href="/pro/wp?section=projects">
-          <a>Projects</a>
+          Projects
         </Link>
       </li>
     </ul>
@@ -34,12 +32,12 @@ const NavigationPro = ({ isHome, className, css }) =>
     <ul className={`${css.links} ${css.secondaryLinks}`}>
       <li>
         <Link prefetch as="/about" href="/pro/wp?section=about-dpla-pro">
-          <a>About</a>
+          About
         </Link>
       </li>
       <li>
         <Link prefetch as="/events" href="/pro/wp?section=events">
-          <a>Events</a>
+          Events
         </Link>
       </li>
     </ul>
@@ -47,12 +45,12 @@ const NavigationPro = ({ isHome, className, css }) =>
     <ul className={`${css.links} ${css.tertiaryLinks}`}>
       <li>
         <Link href={USER_BASE_URL}>
-          <a>DPLA Main Site</a>
+          DPLA Main Site
         </Link>
       </li>
       <li>
         <Link href={USER_BASE_URL + "/news"}>
-          <a>News</a>
+          News
         </Link>
       </li>
     </ul>

--- a/components/MainLayout/components/shared/NavigationUser.js
+++ b/components/MainLayout/components/shared/NavigationUser.js
@@ -12,40 +12,32 @@ class NavigationUser extends React.Component {
           {!isHome &&
             <li>
               <Link prefetch href="/">
-                <a>
-                  Home
-                </a>
+                Home
               </Link>
             </li>}
           <li>
             <Link prefetch href="/browse-by-topic">
-              <a>Browse by Topic</a>
+              Browse by Topic
             </Link>
           </li>
           <li>
             <Link prefetch href="/browse-by-partner">
-              <a>Browse by Partner</a>
+              Browse by Partner
             </Link>
           </li>
           <li>
             <Link prefetch href="/exhibitions">
-              <a>
-                Exhibitions
-              </a>
+              Exhibitions
             </Link>
           </li>
           <li>
             <Link prefetch href="/primary-source-sets">
-              <a>
-                Primary Source Sets
-              </a>
+              Primary Source Sets
             </Link>
           </li>
           <li>
             <Link prefetch href="/lists">
-              <a>
-                My Lists
-              </a>
+              My Lists
             </Link>
           </li>
         </ul>
@@ -53,12 +45,12 @@ class NavigationUser extends React.Component {
         <ul className={`${css.links} ${css.secondaryLinks}`}>
           <li>
             <Link prefetch as="/about" href="/about?section=about-us">
-              <a>About DPLA</a>
+              About DPLA
             </Link>
           </li>
           <li>
             <Link prefetch href="/news">
-              <a>News</a>
+              News
             </Link>
           </li>
         </ul>
@@ -66,7 +58,7 @@ class NavigationUser extends React.Component {
         <ul className={`${css.links} ${css.tertiaryLinks}`}>
           <li>
             <Link href={PRO_BASE_URL}>
-              <a>DPLA Pro</a>
+              DPLA Pro
             </Link>
           </li>
         </ul>

--- a/components/SearchPage/OptionsBar/index.js
+++ b/components/SearchPage/OptionsBar/index.js
@@ -167,21 +167,18 @@ class OptionsBar extends React.Component {
                         list_view: "list"
                       })
                     }}
+                    className={[
+                      css.listViewButton,
+                      this.props.route.query.list_view === "grid"
+                        ? css.viewButtonInactive
+                        : css.viewButtonActive
+                    ].join(" ")}
                   >
-                    <a
-                      className={[
-                        css.listViewButton,
-                        this.props.route.query.list_view === "grid"
-                          ? css.viewButtonInactive
-                          : css.viewButtonActive
-                      ].join(" ")}
-                    >
-                      <img
-                        className={css.viewButtonIcon}
-                        src={this.props.route.query.list_view === "grid" ? inactiveListViewIcon : listViewIcon}
-                        alt="List View"
-                      />
-                    </a>
+                    <img
+                      className={css.viewButtonIcon}
+                      src={this.props.route.query.list_view === "grid" ? inactiveListViewIcon : listViewIcon}
+                      alt="List View"
+                    />
                   </Link>
                   <Link
                     href={{
@@ -190,21 +187,18 @@ class OptionsBar extends React.Component {
                         list_view: "grid"
                       })
                     }}
+                    className={[
+                      css.gridViewButton,
+                      this.props.route.query.list_view === "grid"
+                        ? css.viewButtonActive
+                        : css.viewButtonInactive
+                    ].join(" ")}
                   >
-                    <a
-                      className={[
-                        css.gridViewButton,
-                        this.props.route.query.list_view === "grid"
-                          ? css.viewButtonActive
-                          : css.viewButtonInactive
-                      ].join(" ")}
-                    >
-                      <img
-                        className={css.viewButtonIcon}
-                        src={this.props.route.query.list_view === "grid" ? gridViewIcon : inactiveGridViewIcon}
-                        alt="Grid View"
-                      />
-                    </a>
+                    <img
+                      className={css.viewButtonIcon}
+                      src={this.props.route.query.list_view === "grid" ? gridViewIcon : inactiveGridViewIcon}
+                      alt="Grid View"
+                    />
                   </Link>
                 </div>
               </div>

--- a/components/shared/ListView/ListImage.js
+++ b/components/shared/ListView/ListImage.js
@@ -43,18 +43,17 @@ class ListImage extends React.Component {
       >
         {/* see issue #869 for details on this hack */}
         {item.id !== "http://dp.la/api/items/#sourceResource" &&
-          <Link href={item.linkHref}>
-            <a
-              className={`${css.listItemImageLink} internalItemLink`}
-              title={title}
-              aria-hidden
-            >
-              <img
-                src={updateToDefaultImage ? getDefaultThumbnail(type) : url}
-                alt=""
-                className={css.image}
-              />
-            </a>
+          <Link
+            href={item.linkHref}
+            className={`${css.listItemImageLink} internalItemLink`}
+            title={title}
+            aria-hidden={true}
+          >
+            <img
+              src={updateToDefaultImage ? getDefaultThumbnail(type) : url}
+              alt=""
+              className={css.image}
+            />
           </Link>}
         {/* see issue #869 for details on this hack */}
         {item.id === "http://dp.la/api/items/#sourceResource" &&

--- a/pages/item/[itemId].js
+++ b/pages/item/[itemId].js
@@ -106,26 +106,25 @@ export async function getServerSideProps(context) {
     const language = doc.sourceResource.language &&
         (Array.isArray(doc.sourceResource.language)
       ? doc.sourceResource.language.map(lang => {
-          return lang.name;
+          return lang?.name;
         })
       : doc.sourceResource.language) || "";
-    const strippedDoc = Object.assign({}, doc, { originalRecord: "" });
-    delete strippedDoc.originalRecord;
+    const { originalRecord, ...strippedDoc } = doc;
     return { props : {
       url,
       item: Object.assign({}, doc.sourceResource, {
         id: doc.id,
         thumbnailUrl,
-        contributor: doc.dataProvider,
+        contributor: doc.dataProvider?.name ?? "",
         intermediateProvider: doc.intermediateProvider ? doc.intermediateProvider : "",
         date: date ? date : "",
         language: language ? language : "",
-        partner: doc.provider.name,
+        partner: doc.provider?.name ?? "",
         sourceUrl: doc.isShownAt,
         useDefaultImage: !doc.object,
         edmRights: doc.rights ? doc.rights : "",
         doc: strippedDoc,
-        originalRecord: doc.originalRecord
+        originalRecord
       })
     } };
   } catch (error) {

--- a/pages/search/index.js
+++ b/pages/search/index.js
@@ -92,7 +92,7 @@ const Search = ({ results, numberOfActiveFacets, pageCount, currentPage, pageSiz
 export async function getServerSideProps(context) {
     const query = context.query;
     const rawQ = Array.isArray(query.q) ? query.q[0] : query.q;
-    const normalizedQ = rawQ?.trim() || undefined;
+    const normalizedQ = rawQ?.trim() || null;
     const sort_order = query.sort_order || "";
 
     const q = normalizedQ


### PR DESCRIPTION
## Summary

- Fixes an SSR `TypeError: Cannot read properties of undefined (reading 'name')` crash on the item detail page when a DPLA record has a null `dataProvider` field (the Contributing Institution)
- Guards parallel nullable `.name` reads on `subject` elements and `doc.provider`
- Cleans up related code quality issues found during review

## Root cause

`getServerSideProps` was passing `doc.dataProvider` through as-is to `item.contributor`. For some records the API returns `dataProvider: null`, so `OtherMetadata` crashed unconditionally reading `item.contributor.name`.

Confirmed via **Sentry DPLA-FRONTEND-1KP** — a single SSR crash on the BWS internal staging site at item [`74407a6ff12fdb54a1a49b91870d1ef4`](https://blackwomenssuffrage.dp.la/item/74407a6ff12fdb54a1a49b91870d1ef4), where the API returns `"dataProvider": null`.

## Changes

**`pages/item/[itemId].js`**
- Resolve `contributor` to a string at the SSR boundary: `doc.dataProvider?.name ?? ""` (same pattern dpla-frontend uses via `getDataProviderName`)
- Guard `doc.provider?.name` for the `partner` field
- Guard `lang?.name` in language array mapping
- Replace spread-then-delete `strippedDoc` with destructuring

**`components/ItemComponents/Content/OtherMetadata.js`**
- Conditionally render the Contributing Institution block only when `item.contributor` is present (consistent with how every other optional field in this component is handled)
- Use `item.contributor` directly as a string (no longer needs `.name`)
- Guard `subj?.name` against malformed subject elements; use `subj?.name ?? i` as the React key
- Extract `readMyRights(item.edmRights)` to a local const (was called 3× per render)

## Test plan

- [ ] Visit an item page with a null `dataProvider` — Contributing Institution section should be hidden rather than crashing
- [ ] Visit a normal item page — Contributing Institution should render as before
- [ ] Visit an item page with subjects — subjects should render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes an SSR TypeError on the item detail page when a DPLA record has `dataProvider: null`. The error ("Cannot read properties of undefined (reading 'name')") occurred because server-side props passed `doc.dataProvider` through to `item.contributor` and OtherMetadata unconditionally accessed `item.contributor.name`. The change ensures the site no longer crashes for those records and hides the Contributing Institution block when appropriate.

No deployment, infrastructure, or security actions are required beyond the normal application deployment: this change does not require a manual pipeline trigger or ECS redeployment specifically, does not add/remove/rename environment variables or AWS Secrets Manager keys, includes no database migration, does not change shared infra (CodePipeline/CodeBuild/ECS/IAM), does not change any public-facing API shape or add/remove endpoints, and introduces no new credential handling or auth flows.

## Changes

pages/item/[itemId].js
- Resolve contributor at the SSR boundary to a string using optional chaining: `contributor: doc.dataProvider?.name ?? ""`.
- Guard partner with `provider: doc.provider?.name ?? ""`.
- Guard language mapping with `lang?.name`.
- Replace spread-then-delete `strippedDoc` with destructuring (`const { originalRecord, ...strippedDoc } = doc`) and include `doc: strippedDoc` and `originalRecord` in the returned item.

components/ItemComponents/Content/OtherMetadata.js
- Convert implicit-return arrow component to a block-bodied function and compute `rights` once.
- Conditionally render the Contributing Institution block only when `item.contributor` is present; treat `item.contributor` as a string (pass it directly to FacetLink; do not access `.name`).
- Partner rendering is now conditional on `item.partner`.
- Subject rendering made null-tolerant using `subj?.name`, filters out missing names, and uses `subj?.name ?? i` for React keys.
- Cache `readMyRights(item.edmRights)` into a local const.

Other minor UI/component adjustments (non-functional DOM changes)
- Multiple components updated to remove redundant nested <a> tags inside Next.js Link components (PageHeader, LocalSidebar, Navigation* components, ListImage, OptionsBar). These are DOM-structure changes only and do not alter behavior or public APIs.

## Testing
- Visiting an item with `dataProvider: null` no longer crashes; Contributing Institution is hidden.
- Normal items still render Contributing Institution unchanged.
- Items with subjects render subjects correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->