### PR TITLE
Fix search item links (404) and add styled error pages

### DIFF
--- a/components/ErrorPage/ErrorPage.module.scss
+++ b/components/ErrorPage/ErrorPage.module.scss
@@ -1,0 +1,20 @@
+@import "stylesheets/variables";
+
+.error {
+  text-align: center; ;
+  padding: 3em 2em 6em;
+
+  h1 {
+    color: $jaguar;
+    margin-bottom: 1rem;
+  }
+
+  p {
+    color: $jaguar;
+    margin-bottom: 1.5rem;
+  }
+
+  li + li {
+    margin-top: 0.5rem;
+  }
+}

--- a/components/ErrorPage/index.js
+++ b/components/ErrorPage/index.js
@@ -2,30 +2,25 @@ import React from "react";
 import Link from "next/link";
 import MainLayout from "components/MainLayout";
 import BWSHead from "components/BWSHead";
+import scss from "./ErrorPage.module.scss";
 
 const ErrorPage = ({ pageTitle, heading, body }) => (
   <MainLayout>
     <BWSHead pageTitle={pageTitle} />
-    <div className="sidebarAndContentWrapper">
-      <div className="row">
-        <div className="col-xs-12 col-md-offset-2 col-md-8">
-          <div className="content">
-            <h1>{heading}</h1>
-            <p>{body}</p>
-            <ul>
-              <li>
-                <Link href="/">Return to the home page</Link>
-              </li>
-              <li>
-                <Link href="/search">Search the collection</Link>
-              </li>
-              <li>
-                <Link href="/about">Learn about this project</Link>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
+    <div className={`site-max-width container ${scss.error}`}>
+      <h1>{heading}</h1>
+      <p>{body}</p>
+      <ul>
+        <li>
+          <Link href="/">Return to the home page</Link>
+        </li>
+        <li>
+          <Link href="/search">Search the collection</Link>
+        </li>
+        <li>
+          <Link href="/about">Learn about this project</Link>
+        </li>
+      </ul>
     </div>
   </MainLayout>
 );

--- a/components/ErrorPage/index.js
+++ b/components/ErrorPage/index.js
@@ -1,0 +1,33 @@
+import React from "react";
+import Link from "next/link";
+import MainLayout from "components/MainLayout";
+import BWSHead from "components/BWSHead";
+
+const ErrorPage = ({ pageTitle, heading, body }) => (
+  <MainLayout>
+    <BWSHead pageTitle={pageTitle} />
+    <div className="sidebarAndContentWrapper">
+      <div className="row">
+        <div className="col-xs-12 col-md-offset-2 col-md-8">
+          <div className="content">
+            <h1>{heading}</h1>
+            <p>{body}</p>
+            <ul>
+              <li>
+                <Link href="/">Return to the home page</Link>
+              </li>
+              <li>
+                <Link href="/search">Search the collection</Link>
+              </li>
+              <li>
+                <Link href="/about">Learn about this project</Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </MainLayout>
+);
+
+export default ErrorPage;

--- a/components/SearchPage/MainContent/index.js
+++ b/components/SearchPage/MainContent/index.js
@@ -25,7 +25,7 @@ const MainContent = ({
         {results.length > 0 &&
           <ListView
             route={route}
-            items={addLinkInfoToResults(results, route.query)}
+            items={addLinkInfoToResults(results)}
             viewMode={route.query.list_view}
           />}
         {results.length === 0 &&

--- a/lib/addLinkInfoToResults.js
+++ b/lib/addLinkInfoToResults.js
@@ -1,25 +1,10 @@
 import extractItemId from "./extractItemId";
-import removeQueryParams from "./removeQueryParams";
 
-const addLinkInfoToResults = (results, query) =>
-  results.map((item, idx) => {
-    // const previous = idx > 0 ? idx - 1 : "";
-    // const next = idx < results.length - 1 ? idx + 1 : null;
+const addLinkInfoToResults = (results) =>
+  results.map((item) => {
+    const itemId = item.id ?? extractItemId(item["@id"]);
     return Object.assign({}, item, {
-      linkHref: {
-        pathname: "/item",
-        query: {
-          ...query,
-          itemId: item.id ? item.id : extractItemId(item["@id"])
-        } //, previous, next }
-      },
-      linkAs: {
-        pathname: `/item/${item.id ? item.id : extractItemId(item["@id"])}`,
-        query: Object.assign({}, removeQueryParams(query, ["itemId", "list"])) //, {
-        //   next,
-        //   previous
-        // })
-      }
+      linkHref: `/item/${itemId}`,
     });
   });
 

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,12 @@
+import React from "react";
+import ErrorPage from "components/ErrorPage";
+
+export default function Custom404() {
+  return (
+    <ErrorPage
+      pageTitle="Page Not Found | Black Women's Suffrage"
+      heading="Page not found."
+      body="We're sorry, the page you requested cannot be found. Try one of these instead:"
+    />
+  );
+}

--- a/pages/500.js
+++ b/pages/500.js
@@ -1,0 +1,12 @@
+import React from "react";
+import ErrorPage from "components/ErrorPage";
+
+export default function Custom500() {
+  return (
+    <ErrorPage
+      pageTitle="Server Error | Black Women's Suffrage"
+      heading="An error occurred."
+      body="Thanks for your patience while we work to fix this issue. In the meantime, try one of these:"
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `addLinkInfoToResults` was generating item links as `/item?q=food&itemId=<id>` (a 404) instead of `/item/<id>`. This was introduced in the Next.js 9→14 upgrade (#138), which correctly removed the deprecated `as` prop from all `<Link>` components but left `linkHref` using the old query-parameter form instead of the clean path.
- **Fix**: Update `addLinkInfoToResults` to produce a simple `/item/<id>` string in `linkHref`. Remove the now-unused `linkAs` and `removeQueryParams` import.
- **Error pages**: Added `pages/404.js` and `pages/500.js` with full site branding (Navbar, Footer, favicon) via a shared `components/ErrorPage` component, replacing the unstyled Next.js default error pages.

## Breakage timeline

Broken since **March 21, 2026** (commit `825488e`, the Next.js upgrade). Every search result click has been a 404 for users navigating via the link in the UI.

## Why no Sentry/UptimeRobot alert?

- **UptimeRobot**: monitors `https://blackwomenssuffrage.dp.la/search?q=vote` — checks the search page loads but does not click through to items, so item-level 404s are invisible to it.
- **Sentry**: installed and DSN is configured, but 404s generated by Next.js routing (unmatched URL pattern) do not trigger Sentry events — they're handled by the router before any error capture. Without a custom `_error.js`, there's no hook to capture them. A `pages/404.js` alone doesn't fix this; explicit Sentry instrumentation in `_error.js` would be needed to capture 404s in future (tracked separately).

## Test plan

- [ ] Search for any term (e.g. `/search?q=vote`) and click a result — should navigate to `/item/<id>`, not 404
- [ ] Navigate to a nonexistent path (e.g. `/item/doesnotexist`) — should show styled 404 page with Navbar/Footer
- [ ] Navigate to `/404` directly — styled page renders
- [ ] Verify favicon appears on error pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Fixes item link navigation failures (404 errors) introduced in the Next.js 9→14 upgrade, and adds styled custom error pages to replace unstyled defaults.

## Root Cause & Fix
The Next.js upgrade (commit `825488e`, March 21, 2026) removed support for the deprecated Link `as` prop, but the codebase continued generating query-parameter-based links in `addLinkInfoToResults`. This produced links like `/item?q=food&itemId=<id>` that resulted in 404s.

**Solution**: Refactored `addLinkInfoToResults` to:
- Remove the `query` parameter from the function signature
- Generate clean path-based links: `linkHref` now outputs `/item/<id>` as a simple string instead of an object with `pathname` and `query` properties
- Remove unused `linkAs` and `removeQueryParams` references

Updated `MainContent` in `SearchPage` to call `addLinkInfoToResults` without passing `route.query`.

## Error Page Improvements
- Added shared `ErrorPage` component (`components/ErrorPage/index.js`) that wraps content in `MainLayout` with `Navbar` and `Footer`, ensuring full site branding (including favicon) on error pages
- Added custom 404 page (`pages/404.js`) with "Page not found" messaging and links to home, search, and about
- Added custom 500 page (`pages/500.js`) for server errors
- Added `ErrorPage.module.scss` for centered error messaging layout

## Testing Guidance
- Search results now navigate to `/item/<id>` without 404s
- Nonexistent item paths (e.g., `/item/doesnotexist`) display the styled 404 page
- Error pages include full site navigation and branding

## Implementation Notes
- No environment variables, infrastructure changes, or database migrations required
- Styled error pages are now in place, though Sentry capture of routing 404s would require additional instrumentation in `_error.js` (tracked separately per PR description)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->