### PR TITLE
Fix double semicolon in ErrorPage.module.scss (AI finding)

### DIFF
--- a/components/ErrorPage/ErrorPage.module.scss
+++ b/components/ErrorPage/ErrorPage.module.scss
@@ -1,7 +1,7 @@
 @import "stylesheets/variables";
 
 .error {
-  text-align: center; ;
+  text-align: center;
   padding: 3em 2em 6em;
 
   h1 {


### PR DESCRIPTION
## Summary

- **`components/ErrorPage/ErrorPage.module.scss` line 4**: Remove extra semicolon from `text-align: center; ;`

## Test plan

- [ ] No visual change expected — double semicolons are ignored by CSS parsers but are invalid syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a syntax error in `components/ErrorPage/ErrorPage.module.scss` by removing an extra semicolon from the `.error` class declaration (line 4). The file has been corrected to use proper CSS syntax with a single semicolon after `text-align: center;`.

This is a purely cosmetic fix with no functional impact. CSS parsers ignore double semicolons, but the corrected syntax now adheres to code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->