### PR TITLE
fix(json-ld, sentry): fix coordinates split and set up proper Sentry reporting

### DIFF
--- a/.github/workflows/docker-ecr.yml
+++ b/.github/workflows/docker-ecr.yml
@@ -49,9 +49,11 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           docker build \
           --platform linux/amd64 \
+          --secret id=sentry_auth,env=SENTRY_AUTH_TOKEN \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH_NAME \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM node:22-alpine
 WORKDIR /opt/black-womens-suffrage
 COPY . /opt/black-womens-suffrage
 RUN npm install
-RUN npm run build
+RUN --mount=type=secret,id=sentry_auth \
+    SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth 2>/dev/null || true) \
+    npm run build
 EXPOSE 3000
 
 CMD ["npm", "run", "start"]

--- a/components/ItemComponents/Content/JsonLdMarkup.js
+++ b/components/ItemComponents/Content/JsonLdMarkup.js
@@ -189,8 +189,9 @@ const JsonLdMarkup = ({ item, url }) => {
       var lon = null;
       let coordinates = joinIfArray(x.coordinates);
       if (coordinates !== undefined) {
-        lat = Number(coordinates.split(",")[0]);
-        lon = Number(coordinates.split(",")[1].trim());
+        const [latStr, lonStr] = coordinates.split(",");
+        lat = Number(latStr);
+        lon = Number(lonStr.trim());
       }
       return {
         "@type": "Place",

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -1,7 +1,8 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://9a96f55c94d9e0f332251d903fbb60aa@o4508229092769792.ingest.us.sentry.io/4508229094080512",
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.SENTRY_ENVIRONMENT ?? "development",
   tracesSampleRate: 1,
-  debug: false,
+  debug: process.env.SENTRY_DEBUG === "true",
 });

--- a/sentry.edge.config.js
+++ b/sentry.edge.config.js
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
+  environment: process.env.SENTRY_ENVIRONMENT ?? "development",
   tracesSampleRate: 1,
-  debug: false,
+  debug: process.env.SENTRY_DEBUG === "true",
 });


### PR DESCRIPTION
## Summary

- **`JsonLdMarkup.js`**: `spatial()` was calling `.split(",")` twice on the coordinates string to extract lat/lon — split once into destructured variables instead. (Note: the `provider()` bug from dpla-frontend — returning the result of `.push()` — is not present here; BWS's version correctly assigns `.map()` to a variable before pushing and returning it.)
- **`sentry.client.config.js`**: replaced hardcoded dpla-frontend DSN with `process.env.SENTRY_DSN` — BWS client-side errors were being reported to the dpla-frontend Sentry project instead of tagging correctly under the `bws` environment
- **`sentry.edge.config.js`**: added `environment` and env-driven `debug` to match client and server configs
- **`Dockerfile`**: added `--mount=type=secret,id=sentry_auth` to the `npm run build` step so `SENTRY_AUTH_TOKEN` is available during the Next.js build (source maps were never uploading)
- **`docker-ecr.yml`**: expose `SENTRY_AUTH_TOKEN` from GitHub secret and pass it via `--secret` to the Docker build

## Test plan

- [ ] Confirm item pages with spatial/geographic metadata render correctly
- [ ] After deploy, verify source maps appear in Sentry for new releases
- [ ] Confirm BWS errors in Sentry are tagged with `environment: bws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)